### PR TITLE
Throw KMutableIterator.remove until implemented correctly

### DIFF
--- a/lib/src/collection/iterator.dart
+++ b/lib/src/collection/iterator.dart
@@ -27,7 +27,12 @@ class DartIterator<T> implements KMutableIterator<T> {
 
   @override
   void remove() {
-    list.remove(lastRet);
+    // removing from list is wrong because is is a copy of the original list.
+    // remove should modify the underlying list, not the copy
+    // see how kotlin solved this:
+    // https://github.com/JetBrains/kotlin/blob/ba6da7c40a6cc502508faf6e04fa105b96bc7777/libraries/stdlib/js/src/kotlin/collections/InternalHashCodeMap.kt
+    throw UnimplementedError(
+        "remove() in not yet implemented. Please vote for https://github.com/passsy/dart_kollection/issues/5 for prioritization");
   }
 }
 

--- a/lib/src/collection/set_mutable.dart
+++ b/lib/src/collection/set_mutable.dart
@@ -122,6 +122,11 @@ class _MutableSetIterator<T> extends KMutableIterator<T> {
 
   @override
   void remove() {
-    _set.remove(lastReturned);
+    // removing from list is wrong because is is a copy of the original list.
+    // remove should modify the underlying list, not the copy
+    // see how kotlin solved this:
+    // https://github.com/JetBrains/kotlin/blob/ba6da7c40a6cc502508faf6e04fa105b96bc7777/libraries/stdlib/js/src/kotlin/collections/InternalHashCodeMap.kt
+    throw UnimplementedError(
+        "remove() in not yet implemented. Please vote for https://github.com/passsy/dart_kollection/issues/5 for prioritization");
   }
 }

--- a/lib/src/k_collection_mutable.dart
+++ b/lib/src/k_collection_mutable.dart
@@ -7,6 +7,7 @@ import 'package:dart_kollection/dart_kollection.dart';
  */
 abstract class KMutableCollection<T> implements KCollection<T>, KMutableIterable<T> {
   // Query Operations
+  @override
   KMutableIterator<T> iterator();
 
   // Modification Operations


### PR DESCRIPTION
Prevents #5 from returning wrong results