### PR TITLE
Remove const constructors from interfaces

### DIFF
--- a/lib/src/collection/list_empty.dart
+++ b/lib/src/collection/list_empty.dart
@@ -71,8 +71,6 @@ class EmptyList<T>
 }
 
 class _EmptyIterator<T> extends KListIterator<T> {
-  const _EmptyIterator();
-
   @override
   bool hasNext() => false;
 

--- a/lib/src/collection/set_empty.dart
+++ b/lib/src/collection/set_empty.dart
@@ -36,8 +36,6 @@ class EmptySet<T> with KIterableExtensionsMixin<T>, KCollectionExtensionMixin<T>
 }
 
 class _EmptyIterator<T> extends KIterator<T> {
-  const _EmptyIterator();
-
   @override
   bool hasNext() => false;
 

--- a/lib/src/k_collection.dart
+++ b/lib/src/k_collection.dart
@@ -6,8 +6,6 @@ import 'package:dart_kollection/dart_kollection.dart';
  * @param E the type of elements contained in the collection. The collection is covariant on its element type.
  */
 abstract class KCollection<T> implements KIterable<T>, KCollectionExtension<T> {
-  const KCollection() : super();
-
   // Query Operations
   /**
    * Returns the size of the collection.

--- a/lib/src/k_iterator.dart
+++ b/lib/src/k_iterator.dart
@@ -5,8 +5,6 @@ import 'package:dart_kollection/dart_kollection.dart';
  * Allows to sequentially access the elements.
  */
 abstract class KIterator<T> {
-  const KIterator();
-
   /**
    * Returns the next element in the iteration.
    *
@@ -30,8 +28,6 @@ abstract class KIterator<T> {
  * An iterator over a collection that supports indexed access.
  */
 abstract class KListIterator<T> implements KIterator<T> {
-  const KListIterator();
-
   /**
    * Returns `true` if this list iterator has more elements when
    * traversing the list in the reverse direction.  (In other words,

--- a/lib/src/k_iterator_mutable.dart
+++ b/lib/src/k_iterator_mutable.dart
@@ -5,8 +5,6 @@ import 'package:dart_kollection/dart_kollection.dart';
  * @see MutableCollection.iterator
  */
 abstract class KMutableIterator<T> implements KIterator<T> {
-  const KMutableIterator();
-
   /**
    * Removes from the underlying collection the last element returned by this iterator.
    */


### PR DESCRIPTION
Interfaces aren’t meant to be extended, only implemented. `const` or not `const` is the responsibility of the implementing class, not the interface.


The where required in the early stages of this project because the actual classes where extending not implementing the interfaces.