### PR TITLE
Remove second associateBy parameter, replace with associateByTransform

### DIFF
--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -40,7 +40,12 @@ abstract class KIterableExtensionsMixin<T>
   }
 
   @override
-  KMap<K, V> associateBy<K, V>(K Function(T) keySelector,
+  KMap<K, T> associateBy<K>(K Function(T) keySelector) {
+    return associateByTo(linkedMapOf<K, T>(), keySelector, null);
+  }
+
+  @override
+  KMap<K, V> associateByTransform<K, V>(K Function(T) keySelector,
       [V Function(T) valueTransform]) {
     return associateByTo(linkedMapOf<K, V>(), keySelector, valueTransform);
   }
@@ -49,7 +54,6 @@ abstract class KIterableExtensionsMixin<T>
   M associateByTo<K, V, M extends KMutableMap<K, V>>(
       M destination, K Function(T) keySelector,
       [V Function(T) valueTransform]) {
-    assert(valueTransform != null);
     for (var element in iter) {
       var key = keySelector(element);
       var value = valueTransform == null ? element : valueTransform(element);

--- a/lib/src/k_iterable.dart
+++ b/lib/src/k_iterable.dart
@@ -45,14 +45,24 @@ abstract class KIterableExtension<T> {
 
   /**
    * Returns a [Map] containing the elements from the given collection indexed by the key
+   * returned from [keySelector] function applied to each element.
+   *
+   * If any two elements would have the same key returned by [keySelector] the last one gets added to the map.
+   *
+   * The returned map preserves the entry iteration order of the original collection.
+   */
+  KMap<K, T> associateBy<K>(K Function(T) keySelector);
+
+  /**
+   * Returns a [Map] containing the elements from the given collection indexed by the key
    * returned from [keySelector] function applied to each element. The element can be transformed with [valueTransform].
    *
    * If any two elements would have the same key returned by [keySelector] the last one gets added to the map.
    *
    * The returned map preserves the entry iteration order of the original collection.
    */
-  KMap<K, V> associateBy<K, V>(K Function(T) keySelector,
-      [V Function(T) valueTransform]);
+  KMap<K, V> associateByTransform<K, V>(
+      K Function(T) keySelector, V Function(T) valueTransform);
 
   /**
    * Populates and returns the [destination] mutable map with key-value pairs,

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -17,6 +17,49 @@ void main() {
     });
   });
 
+  group('associate', () {
+    test("associate", () {
+      final list = listOf(["a", "b", "c"]);
+      var result = list.associate((it) => KPair(it.toUpperCase(), it));
+      var expected = mapOf({"A": "a", "B": "b", "C": "c"});
+      expect(result, equals(expected));
+    });
+    test("associate on empty map", () {
+      final list = emptyList<String>();
+      var result = list.associateWith((it) => it.toUpperCase());
+      expect(result, equals(emptyMap()));
+    });
+  });
+
+  group('associateBy', () {
+    test("associateBy", () {
+      final list = listOf(["a", "b", "c"]);
+      var result = list.associateBy((it) => it.toUpperCase());
+      var expected = mapOf({"A": "a", "B": "b", "C": "c"});
+      expect(result, equals(expected));
+    });
+    test("associateBy on empty map", () {
+      final list = emptyList<String>();
+      var result = list.associateWith((it) => it.toUpperCase());
+      expect(result, equals(emptyMap()));
+    });
+  });
+
+  group('associateByTransform', () {
+    test("associateByTransform", () {
+      final list = listOf(["a", "bb", "ccc"]);
+      var result = list.associateByTransform(
+          (it) => it.length, (it) => it.toUpperCase());
+      var expected = mapOf({1: "A", 2: "BB", 3: "CCC"});
+      expect(result, equals(expected));
+    });
+    test("associateByTransform on empty map", () {
+      final list = emptyList<String>();
+      var result = list.associateWith((it) => it.toUpperCase());
+      expect(result, equals(emptyMap()));
+    });
+  });
+
   group('associateWith', () {
     test("associateWith", () {
       final list = listOf(["a", "b", "c"]);

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -43,6 +43,12 @@ void main() {
       var result = list.associateWith((it) => it.toUpperCase());
       expect(result, equals(emptyMap()));
     });
+    test("when conflicting keys, use last ", () {
+      final list = listOf(["a", "b", "c"]);
+      var result = list.associateBy((it) => it.length);
+      var expected = mapOf({1: "c"});
+      expect(result, equals(expected));
+    });
   });
 
   group('associateByTransform', () {


### PR DESCRIPTION
Remove second `associateBy` parameter, replace with `associateByTransform` with two parameters

`associateBy` is much more often used with a single parameter. This wasn’t possible until now because the second lambda value type V couldn’t only be known when the second lambda was provided