### PR TITLE
mapIndexed: Fix generic type problem

### DIFF
--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -625,12 +625,18 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   KList<R> mapIndexed<R>(R Function(int index, T) transform) {
-    return mapIndexedTo(mutableListOf<T>(), transform);
+    var mapped = mapIndexedTo(mutableListOf<R>(), transform);
+    // TODO ping dort-lang/sdk team to check type bug
+    // When in single line: type 'DartMutableList<String>' is not a subtype of type 'Null'
+    return mapped;
   }
 
   @override
   KList<R> mapIndexedNotNull<R>(R Function(int index, T) transform) {
-    return mapIndexedNotNullTo(mutableListOf<T>(), transform);
+    var mapped = mapIndexedNotNullTo(mutableListOf<R>(), transform);
+    // TODO ping dort-lang/sdk team to check type bug
+    // When in single line: type 'DartMutableList<String>' is not a subtype of type 'Null'
+    return mapped;
   }
 
   @override

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -326,6 +326,14 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
     });
   });
 
+  group("map", () {
+    test("map int to string", () {
+      final iterable = iterableOf([1, 2, 3]);
+      expect(iterable.map((it) => it.toString()).toList(),
+          listOf(["1", "2", "3"]));
+    });
+  });
+
   group("mapNotNull", () {
     test("mapNotNull int to string", () {
       final iterable = iterableOf([1, null, 2, null, 3]);
@@ -333,6 +341,67 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
           listOf(["1", "2", "3"]));
     });
   });
+
+  group("mapTo", () {
+    test("mapTo int to string", () {
+      final list = mutableListOf<String>();
+      final iterable = iterableOf([1, 2, 3]);
+      iterable.mapTo(list, (it) => it.toString());
+
+      expect(list, listOf(["1", "2", "3"]));
+    });
+  });
+
+  if (ordered) {
+    group("mapIndexedTo", () {
+      test("mapIndexedTo int to string", () {
+        final list = mutableListOf<String>();
+        final iterable = iterableOf(["a", "b", "c"]);
+        iterable.mapIndexedTo(list, (index, it) => "$index$it");
+
+        expect(list, listOf(["0a", "1b", "2c"]));
+      });
+    });
+  }
+
+  if (ordered) {
+    group("mapIndexed", () {
+      test("mapIndexed int to string", () {
+        final iterable = iterableOf(["a", "b", "c"]);
+        final result = iterable.mapIndexed((index, it) => "$index$it");
+
+        expect(result, listOf(["0a", "1b", "2c"]));
+      });
+    });
+  }
+
+  if (ordered) {
+    group("mapIndexedNotNull", () {
+      test("mapIndexedNotNull int to string", () {
+        final iterable = iterableOf(["a", null, "b", "c"]);
+        expect(
+            iterable.mapIndexedNotNull((index, it) {
+              if (it == null) return null;
+              return "$index$it";
+            }).toList(),
+            listOf(["0a", "2b", "3c"]));
+      });
+    });
+  }
+
+  if (ordered) {
+    group("mapIndexedNotNull", () {
+      test("mapIndexedNotNull int to string", () {
+        final set = linkedSetOf<String>();
+        final iterable = iterableOf(["a", null, "b", "c"]);
+        iterable.mapIndexedNotNullTo(set, (index, it) {
+          if (it == null) return null;
+          return "$index$it";
+        }).toList();
+        expect(set, setOf(["0a", "2b", "3c"]));
+      });
+    });
+  }
 
   group("max", () {
     test("gets max value", () {


### PR DESCRIPTION
Fixes error `type 'DartMutableList<bool>' is not a subtype of type 'Null'`

see tests for details