### PR TITLE
Fix KListIterator.nextIndex

### DIFF
--- a/lib/src/collection/iterator.dart
+++ b/lib/src/collection/iterator.dart
@@ -67,7 +67,7 @@ class InterOpKListIterator<T>
   bool hasPrevious() => cursor != 0;
 
   @override
-  int nextIndex() => cursor;
+  int nextIndex() => cursor + 1 > list.length ? list.length : cursor + 1;
 
   @override
   T previous() {

--- a/test/collection/iterator_test.dart
+++ b/test/collection/iterator_test.dart
@@ -1,0 +1,44 @@
+import 'package:dart_kollection/dart_kollection.dart';
+import 'package:dart_kollection/src/collection/iterator.dart';
+import 'package:test/test.dart';
+
+import '../test/assert_dart.dart';
+
+void main() {
+  group('InterOpKListIterator', () {
+    test("hasNext true", () {
+      final i = InterOpKListIterator(["a", "b"], 0);
+      expect(i.hasNext(), isTrue);
+    });
+
+    test("nextIndex when next exists", () {
+      final i = InterOpKListIterator(["a", "b"], 0);
+      expect(i.nextIndex(), 1);
+    });
+
+    test("hasNext false", () {
+      final i = InterOpKListIterator(["a", "b"], 2);
+      expect(i.hasNext(), isFalse);
+    });
+
+    test("nextIndex returns list size when at end", () {
+      final i = InterOpKListIterator(["a", "b"], 2);
+      expect(i.nextIndex(), 2);
+    });
+
+    test("start index has to be in range (smaller)", () {
+      final e = catchException(() => InterOpKListIterator(["a", "b"], -1));
+      expect(e, TypeMatcher<IndexOutOfBoundsException>());
+    });
+
+    test("start index has to be in range (larger)", () {
+      final e = catchException(() => InterOpKListIterator(["a", "b"], 3));
+      expect(e, TypeMatcher<IndexOutOfBoundsException>());
+    });
+
+    test("start index has to be in range (larger)", () {
+      final i = InterOpKListIterator(["a", "b"], 0);
+      //for (var char in InterOpKIterator()) {}
+    });
+  });
+}

--- a/test/collection/iterator_test.dart
+++ b/test/collection/iterator_test.dart
@@ -6,6 +6,11 @@ import '../test/assert_dart.dart';
 
 void main() {
   group('InterOpKListIterator', () {
+    test("next at pos 0 is first element", () {
+      final i = InterOpKListIterator(["a", "b"], 0);
+      expect(i.next(), "a");
+    });
+
     test("hasNext true", () {
       final i = InterOpKListIterator(["a", "b"], 0);
       expect(i.hasNext(), isTrue);
@@ -16,6 +21,11 @@ void main() {
       expect(i.nextIndex(), 1);
     });
 
+    test("previousIndex when next exists", () {
+      final i = InterOpKListIterator(["a", "b"], 0);
+      expect(i.previousIndex(), -1);
+    });
+
     test("hasNext false", () {
       final i = InterOpKListIterator(["a", "b"], 2);
       expect(i.hasNext(), isFalse);
@@ -24,6 +34,11 @@ void main() {
     test("nextIndex returns list size when at end", () {
       final i = InterOpKListIterator(["a", "b"], 2);
       expect(i.nextIndex(), 2);
+    });
+
+    test("previousIndex when next exists", () {
+      final i = InterOpKListIterator(["a", "b"], 2);
+      expect(i.previousIndex(), 1);
     });
 
     test("start index has to be in range (smaller)", () {
@@ -39,6 +54,31 @@ void main() {
     test("start index has to be in range (larger)", () {
       final i = InterOpKListIterator(["a", "b"], 0);
       //for (var char in InterOpKIterator()) {}
+    });
+
+    test("remove is not implemented", () {
+      final i = InterOpKListIterator(["a", "b"], 0);
+      final e = catchException(() => i.remove());
+      expect(e, TypeMatcher<UnimplementedError>());
+    });
+
+    test("add adds item to underlying list", () {
+      var dartList = ["a", "b"];
+      final i = InterOpKListIterator(dartList, 0);
+      i.add("c");
+      expect(dartList, equals(["c", "a", "b"]));
+    });
+
+    test("set modifies current item", () {
+      var dartList = ["a", "b"];
+      final i = InterOpKListIterator(dartList, 0);
+      expect(i.next(), equals("a"));
+      i.set("x");
+      expect(dartList, equals(["x", "b"]));
+      expect(i.previous(), equals("x"));
+      expect(i.next(), equals("x"));
+      expect(i.next(), equals("b"));
+      expect(i.previous(), equals("b"));
     });
   });
 }

--- a/test/dart_kollection_test.dart
+++ b/test/dart_kollection_test.dart
@@ -1,5 +1,6 @@
 import 'collection/collection_test.dart' as collection_test;
 import 'collection/iterable_extensions_test.dart' as iterable_extensions_test;
+import 'collection/iterator_test.dart' as iterator_test;
 import 'collection/list_empty_test.dart' as list_empty_test;
 import 'collection/list_extensions_test.dart' as list_extensions_test;
 import 'collection/list_mutable_extensions_test.dart'
@@ -20,6 +21,7 @@ import 'tuples_test.dart' as tuples_test;
 main() {
   collection_test.main();
   iterable_extensions_test.main();
+  iterator_test.main();
   list_empty_test.main();
   list_extensions_test.main();
   list_mutable_extensions_test.main();

--- a/test/test/assert_dart.dart
+++ b/test/test/assert_dart.dart
@@ -1,0 +1,11 @@
+import 'package:test/test.dart';
+
+/// returns the caught exception thrown in [block]
+dynamic catchException(Function block) {
+  try {
+    block();
+    fail("block did not throw");
+  } catch (e) {
+    return e;
+  }
+}


### PR DESCRIPTION
next index was off by one (`-1`).

It now also returns the length of the list when `hasNext() == false` as documented