### PR TITLE
fix KIterable.none() is always true

### DIFF
--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -829,7 +829,7 @@ abstract class KIterableExtensionsMixin<T>
   @override
   bool none([bool Function(T) predicate]) {
     if (this is KCollection && (this as KCollection).isEmpty()) return true;
-    if (predicate == null) return false;
+    if (predicate == null) return !iterator().hasNext();
     for (final element in iter) {
       if (predicate(element)) {
         return false;

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -518,6 +518,26 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
     }
   });
 
+  group("none", () {
+    test("no matching returns true", () {
+      final items = iterableOf(["paul", "john", "max", "lisa"]);
+      expect(items.none((it) => it.contains("y")), isTrue);
+    });
+    test("matching returns false", () {
+      final items = iterableOf(["paul", "john", "max", "lisa"]);
+      expect(items.none((it) => it.contains("p")), isFalse);
+    });
+
+    test("none without predicate returns false when iterable has items", () {
+      final items = iterableOf(["paul", "john", "max", "lisa"]);
+      expect(items.none(), isFalse);
+    });
+
+    test("empty returns always true", () {
+      expect(emptyIterable().none(), isTrue);
+    });
+  });
+
   group("plus", () {
     test("concat two iterables", () {
       final result = iterableOf([1, 2, 3]).plus(iterableOf([4, 5, 6]));


### PR DESCRIPTION
Always returned `false` for `KIterable`. Worked fine for `KCollection`s

[kotlin src](https://github.com/JetBrains/kotlin/blob/d88fd8aa6f0865b59f84fd28a8b77487b7712da1/libraries/stdlib/common/src/generated/_Collections.kt#L1752)