### PR TITLE
Validate input arguments

### DIFF
--- a/lib/src/collection/list.dart
+++ b/lib/src/collection/list.dart
@@ -34,12 +34,19 @@ class DartList<T>
 
   @override
   bool containsAll(KCollection<T> elements) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     return elements.all((it) => _list.contains(it));
   }
 
   @override
   T get(int index) {
-    if (index == null) throw ArgumentError("index can't be null");
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      return true;
+    }());
     if (index < 0 || index >= size) {
       throw IndexOutOfBoundsException("index: $index, size: $size");
     }
@@ -63,7 +70,10 @@ class DartList<T>
 
   @override
   KListIterator<T> listIterator([int index = 0]) {
-    if (index == null) throw ArgumentError("index can't be null");
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      return true;
+    }());
     return InterOpKListIterator(_list, index);
   }
 
@@ -72,14 +82,16 @@ class DartList<T>
 
   @override
   KList<T> subList(int fromIndex, int toIndex) {
-    if (fromIndex == null) throw ArgumentError("fromIndex can't be null");
-    if (toIndex == null) throw ArgumentError("toIndex can't be null");
+    assert(() {
+      if (fromIndex == null) throw ArgumentError("fromIndex can't be null");
+      if (toIndex == null) throw ArgumentError("toIndex can't be null");
+      if (fromIndex > toIndex)
+        throw ArgumentError("fromIndex: $fromIndex > toIndex: $toIndex");
+      return true;
+    }());
     if (fromIndex < 0 || toIndex > size) {
       throw IndexOutOfBoundsException(
           "fromIndex: $fromIndex, toIndex: $toIndex, size: $size");
-    }
-    if (fromIndex > toIndex) {
-      throw ArgumentError("fromIndex: $fromIndex > toIndex: $toIndex");
     }
     return DartList(_list.sublist(fromIndex, toIndex));
   }

--- a/lib/src/collection/list_empty.dart
+++ b/lib/src/collection/list_empty.dart
@@ -21,14 +21,20 @@ class EmptyList<T>
 
   @override
   T get(int index) {
-    if (index == null) throw ArgumentError("index can't be null");
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      return true;
+    }());
     throw IndexOutOfBoundsException(
         "Empty list doesn't contain element at index $index.");
   }
 
   @override
   T operator [](int index) {
-    if (index == null) throw ArgumentError("index can't be null");
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      return true;
+    }());
     throw IndexOutOfBoundsException(
         "Empty list doesn't contain element at index $index.");
   }
@@ -47,7 +53,10 @@ class EmptyList<T>
 
   @override
   KListIterator<T> listIterator([int index = 0]) {
-    if (index == null) throw ArgumentError("index can't be null");
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      return true;
+    }());
     return _EmptyIterator();
   }
 
@@ -56,8 +65,11 @@ class EmptyList<T>
 
   @override
   KList<T> subList(int fromIndex, int toIndex) {
-    if (fromIndex == null) throw ArgumentError("fromIndex can't be null");
-    if (toIndex == null) throw ArgumentError("toIndex can't be null");
+    assert(() {
+      if (fromIndex == null) throw ArgumentError("fromIndex can't be null");
+      if (toIndex == null) throw ArgumentError("toIndex can't be null");
+      return true;
+    }());
     if (fromIndex == 0 && toIndex == 0) return this;
     throw IndexOutOfBoundsException("fromIndex: $fromIndex, toIndex: $toIndex");
   }

--- a/lib/src/collection/list_mutable.dart
+++ b/lib/src/collection/list_mutable.dart
@@ -37,12 +37,19 @@ class DartMutableList<T>
 
   @override
   bool containsAll(KCollection<T> elements) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     return elements.all((it) => _list.contains(it));
   }
 
   @override
   T get(int index) {
-    if (index == null) throw ArgumentError("index can't be null");
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      return true;
+    }());
     if (index < 0 || index >= size) {
       throw IndexOutOfBoundsException("index: $index, size: $size");
     }
@@ -81,18 +88,31 @@ class DartMutableList<T>
 
   @override
   bool addAll(KIterable<T> elements) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     _list.addAll(elements.iter);
     return true;
   }
 
   @override
   bool addAllAt(int index, KCollection<T> elements) {
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     _list.insertAll(index, elements.iter);
     return true;
   }
 
   @override
   void addAt(int index, T element) {
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      return true;
+    }());
     _list.insert(index, element);
   }
 
@@ -103,10 +123,20 @@ class DartMutableList<T>
   bool remove(T element) => _list.remove(element);
 
   @override
-  T removeAt(int index) => _list.removeAt(index);
+  T removeAt(int index) {
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      return true;
+    }());
+    return _list.removeAt(index);
+  }
 
   @override
   T set(int index, T element) {
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      return true;
+    }());
     final old = _list[index];
     _list[index] = element;
     return old;
@@ -117,6 +147,10 @@ class DartMutableList<T>
 
   @override
   bool removeAll(KIterable<T> elements) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     var changed = false;
     for (var value in elements.iter) {
       changed |= _list.remove(value);
@@ -126,20 +160,27 @@ class DartMutableList<T>
 
   @override
   bool retainAll(KIterable<T> elements) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     _list.removeWhere((it) => !elements.contains(it));
     return true;
   }
 
   @override
   KMutableList<T> subList(int fromIndex, int toIndex) {
-    if (fromIndex == null) throw ArgumentError("fromIndex can't be null");
-    if (toIndex == null) throw ArgumentError("toIndex can't be null");
+    assert(() {
+      if (fromIndex == null) throw ArgumentError("fromIndex can't be null");
+      if (toIndex == null) throw ArgumentError("toIndex can't be null");
+      if (fromIndex > toIndex) {
+        throw ArgumentError("fromIndex: $fromIndex > toIndex: $toIndex");
+      }
+      return true;
+    }());
     if (fromIndex < 0 || toIndex > size) {
       throw IndexOutOfBoundsException(
           "fromIndex: $fromIndex, toIndex: $toIndex, size: $size");
-    }
-    if (fromIndex > toIndex) {
-      throw ArgumentError("fromIndex: $fromIndex > toIndex: $toIndex");
     }
     return DartMutableList(_list.sublist(fromIndex, toIndex));
   }

--- a/lib/src/collection/map_mutable.dart
+++ b/lib/src/collection/map_mutable.dart
@@ -71,6 +71,10 @@ class DartMutableMap<K, V>
 
   @override
   void putAll(KMap<K, V> from) {
+    assert(() {
+      if (from == null) throw ArgumentError("from can't be null");
+      return true;
+    }());
     for (var entry in from.entries.iter) {
       _map[entry.key] = entry.value;
     }

--- a/lib/src/collection/set.dart
+++ b/lib/src/collection/set.dart
@@ -24,6 +24,10 @@ class DartSet<T>
 
   @override
   bool containsAll(KCollection<T> elements) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     return elements.all((it) => _set.contains(it));
   }
 

--- a/lib/src/collection/set_empty.dart
+++ b/lib/src/collection/set_empty.dart
@@ -13,7 +13,13 @@ class EmptySet<T>
   bool contains(T element) => false;
 
   @override
-  bool containsAll(KCollection<T> elements) => elements.isEmpty();
+  bool containsAll(KCollection<T> elements) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
+    return elements.isEmpty();
+  }
 
   @override
   bool isEmpty() => true;

--- a/lib/src/collection/set_mutable.dart
+++ b/lib/src/collection/set_mutable.dart
@@ -89,6 +89,10 @@ class DartMutableSet<T>
 
   @override
   bool retainAll(KIterable<T> elements) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     final oldSize = size;
     _set.removeWhere((it) => !elements.contains(it));
     return oldSize != size;

--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -8,7 +8,10 @@ abstract class KIterableExtensionsMixin<T>
     implements KIterableExtension<T>, KIterable<T> {
   @override
   bool all([bool Function(T element) predicate]) {
-    assert(predicate != null);
+    assert(() {
+      if (predicate == null) throw ArgumentError("predicate can't be null");
+      return true;
+    }());
     if (this is KCollection && (this as KCollection).isEmpty()) return true;
     for (var element in iter) {
       if (!predicate(element)) {
@@ -54,6 +57,11 @@ abstract class KIterableExtensionsMixin<T>
   M associateByTo<K, V, M extends KMutableMap<K, V>>(
       M destination, K Function(T) keySelector,
       [V Function(T) valueTransform]) {
+    assert(() {
+      if (destination == null) throw ArgumentError("destination can't be null");
+      if (keySelector == null) throw ArgumentError("keySelector can't be null");
+      return true;
+    }());
     for (var element in iter) {
       var key = keySelector(element);
       var value = valueTransform == null ? element : valueTransform(element);
@@ -65,7 +73,10 @@ abstract class KIterableExtensionsMixin<T>
   @override
   M associateTo<K, V, M extends KMutableMap<K, V>>(
       M destination, KPair<K, V> Function(T) transform) {
-    assert(transform != null);
+    assert(() {
+      if (transform == null) throw ArgumentError("transform can't be null");
+      return true;
+    }());
     for (var element in iter) {
       var pair = transform(element);
       destination.put(pair.first, pair.second);
@@ -81,7 +92,11 @@ abstract class KIterableExtensionsMixin<T>
   @override
   M associateWithTo<V, M extends KMutableMap<T, V>>(
       M destination, V Function(T) valueSelector) {
-    assert(valueSelector != null);
+    assert(() {
+      if (valueSelector == null)
+        throw ArgumentError("valueSelector can't be null");
+      return true;
+    }());
     for (var element in iter) {
       destination.put(element, valueSelector(element));
     }
@@ -90,7 +105,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   double averageBy(num Function(T) selector) {
-    assert(selector != null);
+    assert(() {
+      if (selector == null) throw ArgumentError("selector can't be null");
+      return true;
+    }());
     num sum = 0.0;
     var count = 0;
     for (final element in iter) {
@@ -102,11 +120,19 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   KList<KList<T>> chunked(int size) {
+    assert(() {
+      if (size == null) throw ArgumentError("size can't be null");
+      return true;
+    }());
     return windowed(size, step: size, partialWindows: true);
   }
 
   @override
   KList<R> chunkedTransform<R>(int size, R Function(KList<T>) transform) {
+    assert(() {
+      if (size == null) throw ArgumentError("size can't be null");
+      return true;
+    }());
     return windowedTransform(size, transform, step: size, partialWindows: true);
   }
 
@@ -138,7 +164,10 @@ abstract class KIterableExtensionsMixin<T>
   KList<T> distinct() => toMutableSet().toList();
 
   KList<T> distinctBy<K>(K Function(T) selector) {
-    assert(selector != null);
+    assert(() {
+      if (selector == null) throw ArgumentError("selector can't be null");
+      return true;
+    }());
     final set = hashSetOf<K>();
     final list = mutableListOf<T>();
     for (final element in iter) {
@@ -152,6 +181,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   KList<T> drop(int n) {
+    assert(() {
+      if (n == null) throw ArgumentError("n can't be null");
+      return true;
+    }());
     final list = mutableListOf<T>();
     var count = 0;
     for (final item in iter) {
@@ -164,7 +197,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   KList<T> dropWhile(bool Function(T) predicate) {
-    assert(predicate != null);
+    assert(() {
+      if (predicate == null) throw ArgumentError("predicate can't be null");
+      return true;
+    }());
     var yielding = false;
     var list = mutableListOf<T>();
     for (final item in iter) {
@@ -182,7 +218,11 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   T elementAt(int index) {
-    if (index == null) throw ArgumentError("index can't be null");
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      return true;
+    }());
+
     return elementAtOrElse(index, (int index) {
       throw IndexOutOfBoundsException(
           "Collection doesn't contain element at index $index.");
@@ -191,9 +231,12 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   T elementAtOrElse(int index, T Function(int) defaultValue) {
-    if (index == null) throw ArgumentError("index can't be null");
-    if (defaultValue == null)
-      throw ArgumentError("defaultValue function can't be null");
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      if (defaultValue == null)
+        throw ArgumentError("defaultValue function can't be null");
+      return true;
+    }());
     if (index < 0) {
       return defaultValue(index);
     }
@@ -210,7 +253,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   T elementAtOrNull(int index) {
-    if (index == null) throw ArgumentError("index can't be null");
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      return true;
+    }());
     if (index < 0) {
       return null;
     }
@@ -242,7 +288,10 @@ abstract class KIterableExtensionsMixin<T>
   @override
   C filterIndexedTo<C extends KMutableCollection<T>>(
       C destination, bool Function(int index, T) predicate) {
-    assert(predicate != null);
+    assert(() {
+      if (predicate == null) throw ArgumentError("predicate can't be null");
+      return true;
+    }());
     var i = 0;
     for (final element in iter) {
       if (predicate(i++, element)) {
@@ -292,7 +341,10 @@ abstract class KIterableExtensionsMixin<T>
   @override
   C filterNotTo<C extends KMutableCollection<T>>(
       C destination, bool Function(T) predicate) {
-    assert(predicate != null);
+    assert(() {
+      if (predicate == null) throw ArgumentError("predicate can't be null");
+      return true;
+    }());
     for (final element in iter) {
       if (!predicate(element)) {
         destination.add(element);
@@ -304,7 +356,11 @@ abstract class KIterableExtensionsMixin<T>
   @override
   C filterTo<C extends KMutableCollection<T>>(
       C destination, bool Function(T) predicate) {
-    assert(predicate != null);
+    assert(() {
+      if (predicate == null) throw ArgumentError("predicate can't be null");
+      if (destination == null) throw ArgumentError("destination can't be null");
+      return true;
+    }());
     for (final element in iter) {
       if (predicate(element)) {
         destination.add(element);
@@ -315,13 +371,19 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   T find(bool Function(T) predicate) {
-    assert(predicate != null);
+    assert(() {
+      if (predicate == null) throw ArgumentError("predicate can't be null");
+      return true;
+    }());
     return firstOrNull(predicate);
   }
 
   @override
   T findLast(bool Function(T) predicate) {
-    assert(predicate != null);
+    assert(() {
+      if (predicate == null) throw ArgumentError("predicate can't be null");
+      return true;
+    }());
     return lastOrNull(predicate);
   }
 
@@ -377,7 +439,11 @@ abstract class KIterableExtensionsMixin<T>
   @override
   C flatMapTo<R, C extends KMutableCollection<R>>(
       C destination, KIterable<R> Function(T) transform) {
-    assert(transform != null);
+    assert(() {
+      if (destination == null) throw ArgumentError("destination can't be null");
+      if (transform == null) throw ArgumentError("transform can't be null");
+      return true;
+    }());
     for (var element in iter) {
       final list = transform(element);
       destination.addAll(list);
@@ -387,7 +453,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   R fold<R>(R initial, R Function(R acc, T) operation) {
-    assert(operation != null);
+    assert(() {
+      if (operation == null) throw ArgumentError("operation can't be null");
+      return true;
+    }());
     var accumulator = initial;
     for (final element in iter) {
       accumulator = operation(accumulator, element);
@@ -397,7 +466,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   R foldIndexed<R>(R initial, R Function(int index, R acc, T) operation) {
-    assert(operation != null);
+    assert(() {
+      if (operation == null) throw ArgumentError("operation can't be null");
+      return true;
+    }());
     var index = 0;
     var accumulator = initial;
     for (final element in iter) {
@@ -407,8 +479,11 @@ abstract class KIterableExtensionsMixin<T>
   }
 
   @override
-  void forEach(void action(T element)) {
-    assert(action != null);
+  void forEach(void Function(T element) action) {
+    assert(() {
+      if (action == null) throw ArgumentError("action can't be null");
+      return true;
+    }());
     var i = iterator();
     while (i.hasNext()) {
       var element = i.next();
@@ -418,7 +493,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   void forEachIndexed(void Function(int index, T element) action) {
-    assert(action != null);
+    assert(() {
+      if (action == null) throw ArgumentError("action can't be null");
+      return true;
+    }());
     var index = 0;
     for (final item in iter) {
       action(index++, item);
@@ -442,8 +520,11 @@ abstract class KIterableExtensionsMixin<T>
   @override
   M groupByTo<K, M extends KMutableMap<K, KMutableList<T>>>(
       M destination, K Function(T) keySelector) {
-    assert(destination != null);
-    assert(keySelector != null);
+    assert(() {
+      if (destination == null) throw ArgumentError("destination can't be null");
+      if (keySelector == null) throw ArgumentError("keySelector can't be null");
+      return true;
+    }());
     for (final element in iter) {
       final key = keySelector(element);
       final list = destination.getOrPut(key, () => mutableListOf<T>());
@@ -455,9 +536,13 @@ abstract class KIterableExtensionsMixin<T>
   @override
   M groupByToTransform<K, V, M extends KMutableMap<K, KMutableList<V>>>(
       M destination, K Function(T) keySelector, V Function(T) valueTransform) {
-    assert(destination != null);
-    assert(keySelector != null);
-    assert(valueTransform != null);
+    assert(() {
+      if (destination == null) throw ArgumentError("destination can't be null");
+      if (keySelector == null) throw ArgumentError("keySelector can't be null");
+      if (valueTransform == null)
+        throw ArgumentError("valueTransform can't be null");
+      return true;
+    }());
     for (final element in iter) {
       final key = keySelector(element);
       final list = destination.getOrPut(key, () => mutableListOf<V>());
@@ -479,7 +564,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   int indexOfFirst(bool Function(T) predicate) {
-    assert(predicate != null);
+    assert(() {
+      if (predicate == null) throw ArgumentError("predicate can't be null");
+      return true;
+    }());
     var index = 0;
     for (var item in iter) {
       if (predicate(item)) {
@@ -491,7 +579,10 @@ abstract class KIterableExtensionsMixin<T>
   }
 
   int indexOfLast(bool Function(T) predicate) {
-    assert(predicate != null);
+    assert(() {
+      if (predicate == null) throw ArgumentError("predicate can't be null");
+      return true;
+    }());
     var lastIndex = -1;
     var index = 0;
     for (var item in iter) {
@@ -637,7 +728,10 @@ abstract class KIterableExtensionsMixin<T>
   @override
   C mapIndexedNotNullTo<R, C extends KMutableCollection<R>>(
       C destination, R Function(int index, T) transform) {
-    assert(transform != null);
+    assert(() {
+      if (transform == null) throw ArgumentError("transform can't be null");
+      return true;
+    }());
     var index = 0;
     for (final item in iter) {
       var element = transform(index++, item);
@@ -651,7 +745,10 @@ abstract class KIterableExtensionsMixin<T>
   @override
   C mapIndexedTo<R, C extends KMutableCollection<R>>(
       C destination, R Function(int index, T) transform) {
-    assert(transform != null);
+    assert(() {
+      if (transform == null) throw ArgumentError("transform can't be null");
+      return true;
+    }());
     var index = 0;
     for (final item in iter) {
       destination.add(transform(index++, item));
@@ -670,7 +767,11 @@ abstract class KIterableExtensionsMixin<T>
   @override
   C mapNotNullTo<R, C extends KMutableCollection<R>>(
       C destination, R Function(T) transform) {
-    assert(transform != null);
+    assert(() {
+      if (destination == null) throw ArgumentError("destination can't be null");
+      if (transform == null) throw ArgumentError("transform can't be null");
+      return true;
+    }());
     for (final item in iter) {
       var result = transform(item);
       if (result != null) {
@@ -683,7 +784,11 @@ abstract class KIterableExtensionsMixin<T>
   @override
   C mapTo<R, C extends KMutableCollection<R>>(
       C destination, R Function(T) transform) {
-    assert(transform != null);
+    assert(() {
+      if (destination == null) throw ArgumentError("destination can't be null");
+      if (transform == null) throw ArgumentError("transform can't be null");
+      return true;
+    }());
     for (var item in iter) {
       destination.add(transform(item));
     }
@@ -713,7 +818,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   T maxBy<R extends Comparable<R>>(R Function(T) selector) {
-    assert(selector != null);
+    assert(() {
+      if (selector == null) throw ArgumentError("selector can't be null");
+      return true;
+    }());
     final i = iterator();
     if (!iterator().hasNext()) return null;
     T maxElement = i.next();
@@ -731,6 +839,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   T maxWith(Comparator<T> comparator) {
+    assert(() {
+      if (comparator == null) throw ArgumentError("comparator can't be null");
+      return true;
+    }());
     final i = iterator();
     if (!i.hasNext()) return null;
     var max = i.next();
@@ -766,6 +878,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   KList<T> minus(KIterable<T> elements) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     if (this is KCollection && (this as KCollection).isEmpty()) {
       return this.toList();
     }
@@ -791,7 +907,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   T minBy<R extends Comparable<R>>(R Function(T) selector) {
-    assert(selector != null);
+    assert(() {
+      if (selector == null) throw ArgumentError("selector can't be null");
+      return true;
+    }());
     final i = iterator();
     if (!iterator().hasNext()) return null;
     T minElement = i.next();
@@ -809,6 +928,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   T minWith(Comparator<T> comparator) {
+    assert(() {
+      if (comparator == null) throw ArgumentError("comparator can't be null");
+      return true;
+    }());
     final i = iterator();
     if (!i.hasNext()) return null;
     var min = i.next();
@@ -835,7 +958,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   void onEach(void Function(T) action) {
-    assert(action != null);
+    assert(() {
+      if (action == null) throw ArgumentError("action can't be null");
+      return true;
+    }());
     for (final element in iter) {
       action(element);
     }
@@ -843,7 +969,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   KPair<KList<T>, KList<T>> partition(bool Function(T) predicate) {
-    assert(predicate != null);
+    assert(() {
+      if (predicate == null) throw ArgumentError("predicate can't be null");
+      return true;
+    }());
     final first = mutableListOf<T>();
     final second = mutableListOf<T>();
     for (final element in iter) {
@@ -858,6 +987,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   KList<T> plus(KIterable<T> elements) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     final result = mutableListOf<T>();
     result.addAll(this.asIterable());
     result.addAll(elements);
@@ -876,6 +1009,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   S reduce<S>(S Function(S acc, T) operation) {
+    assert(() {
+      if (operation == null) throw ArgumentError("operation can't be null");
+      return true;
+    }());
     final i = iterator();
     if (!i.hasNext())
       throw UnsupportedError("Empty collection can't be reduced.");
@@ -888,6 +1025,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   S reduceIndexed<S>(S Function(int index, S acc, T) operation) {
+    assert(() {
+      if (operation == null) throw ArgumentError("operation can't be null");
+      return true;
+    }());
     final i = iterator();
     if (!i.hasNext())
       throw UnsupportedError("Empty collection can't be reduced.");
@@ -985,19 +1126,32 @@ abstract class KIterableExtensionsMixin<T>
   KList<T> sorted() => sortedWith(naturalOrder());
 
   @override
-  KList<T> sortedBy<R extends Comparable<R>>(R Function(T) selector) =>
-      sortedWith(compareBy(selector));
+  KList<T> sortedBy<R extends Comparable<R>>(R Function(T) selector) {
+    assert(() {
+      if (selector == null) throw ArgumentError("selector can't be null");
+      return true;
+    }());
+    return sortedWith(compareBy(selector));
+  }
 
   @override
-  KList<T> sortedByDescending<R extends Comparable<R>>(
-          R Function(T) selector) =>
-      sortedWith(compareByDescending(selector));
+  KList<T> sortedByDescending<R extends Comparable<R>>(R Function(T) selector) {
+    assert(() {
+      if (selector == null) throw ArgumentError("selector can't be null");
+      return true;
+    }());
+    return sortedWith(compareByDescending(selector));
+  }
 
   @override
   KList<T> sortedDescending() => sortedWith(reverseOrder());
 
   @override
   KList<T> sortedWith(Comparator<T> comparator) {
+    assert(() {
+      if (comparator == null) throw ArgumentError("comparator can't be null");
+      return true;
+    }());
     final mutableList = toMutableList();
     mutableList.list.sort(comparator);
     return mutableList;
@@ -1005,6 +1159,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   KSet<T> subtract(KIterable<T> other) {
+    assert(() {
+      if (other == null) throw ArgumentError("other can't be null");
+      return true;
+    }());
     final set = toMutableSet();
     set.removeAll(other);
     return set;
@@ -1025,6 +1183,10 @@ abstract class KIterableExtensionsMixin<T>
   }
 
   int sumBy(int Function(T) selector) {
+    assert(() {
+      if (selector == null) throw ArgumentError("selector can't be null");
+      return true;
+    }());
     int sum = 0;
     for (final element in iter) {
       sum += selector(element);
@@ -1033,6 +1195,10 @@ abstract class KIterableExtensionsMixin<T>
   }
 
   double sumByDouble(double Function(T) selector) {
+    assert(() {
+      if (selector == null) throw ArgumentError("selector can't be null");
+      return true;
+    }());
     double sum = 0.0;
     for (final element in iter) {
       sum += selector(element);
@@ -1042,6 +1208,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   KList<T> take(int n) {
+    assert(() {
+      if (n == null) throw ArgumentError("n can't be null");
+      return true;
+    }());
     if (n < 0) {
       throw ArgumentError("Requested element count $n is less than zero.");
     }
@@ -1063,6 +1233,10 @@ abstract class KIterableExtensionsMixin<T>
   }
 
   C toCollection<C extends KMutableCollection<T>>(C destination) {
+    assert(() {
+      if (destination == null) throw ArgumentError("destination can't be null");
+      return true;
+    }());
     for (final item in iter) {
       destination.add(item);
     }
@@ -1086,6 +1260,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   KSet<T> union(KIterable<T> other) {
+    assert(() {
+      if (other == null) throw ArgumentError("other can't be null");
+      return true;
+    }());
     final set = toMutableSet();
     set.addAll(other);
     return set;
@@ -1094,6 +1272,13 @@ abstract class KIterableExtensionsMixin<T>
   @override
   KList<KList<T>> windowed(int size,
       {int step = 1, bool partialWindows = false}) {
+    assert(() {
+      if (size == null) throw ArgumentError("size can't be null");
+      if (step == null) throw ArgumentError("step can't be null");
+      if (partialWindows == null)
+        throw ArgumentError("partialWindows can't be null");
+      return true;
+    }());
     final list = this.toList();
     final thisSize = list.size;
     final result = mutableListOf<KList<T>>();
@@ -1111,7 +1296,14 @@ abstract class KIterableExtensionsMixin<T>
   @override
   KList<R> windowedTransform<R>(int size, R Function(KList<T>) transform,
       {int step = 1, bool partialWindows = false}) {
-    assert(transform != null);
+    assert(() {
+      if (size == null) throw ArgumentError("size can't be null");
+      if (transform == null) throw ArgumentError("transform can't be null");
+      if (step == null) throw ArgumentError("step can't be null");
+      if (partialWindows == null)
+        throw ArgumentError("partialWindows can't be null");
+      return true;
+    }());
     final list = this.toList();
     final thisSize = list.size;
     final result = mutableListOf<R>();
@@ -1133,6 +1325,11 @@ abstract class KIterableExtensionsMixin<T>
   @override
   KList<V> zipTransform<R, V>(
       KIterable<R> other, V Function(T a, R b) transform) {
+    assert(() {
+      if (other == null) throw ArgumentError("other can't be null");
+      if (transform == null) throw ArgumentError("transform can't be null");
+      return true;
+    }());
     final first = iterator();
     final second = other.iterator();
     final list = mutableListOf<V>();
@@ -1148,6 +1345,10 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   KList<R> zipWithNextTransform<R>(R Function(T a, T b) transform) {
+    assert(() {
+      if (transform == null) throw ArgumentError("transform can't be null");
+      return true;
+    }());
     final i = iterator();
     if (!i.hasNext()) {
       return emptyList();

--- a/lib/src/extension/iterable_mutable_extension_mixin.dart
+++ b/lib/src/extension/iterable_mutable_extension_mixin.dart
@@ -12,6 +12,10 @@ abstract class KMutableIterableExtensionsMixin<T>
 
   bool _filterInPlace(
       bool Function(T) predicate, bool predicateResultToRemove) {
+    assert(() {
+      if (predicate == null) throw ArgumentError("predicate can't be null");
+      return true;
+    }());
     var result = false;
     var i = iterator();
     while (i.hasNext())

--- a/lib/src/extension/list_extension_mixin.dart
+++ b/lib/src/extension/list_extension_mixin.dart
@@ -3,6 +3,10 @@ import 'package:dart_kollection/dart_kollection.dart';
 abstract class KListExtensionsMixin<T> implements KListExtension<T>, KList<T> {
   @override
   KList<T> dropLast(int n) {
+    assert(() {
+      if (n == null) throw ArgumentError("n can't be null");
+      return true;
+    }());
     var count = size - n;
     if (count < 0) {
       count = 0;
@@ -12,7 +16,10 @@ abstract class KListExtensionsMixin<T> implements KListExtension<T>, KList<T> {
 
   @override
   KList<T> dropLastWhile(bool Function(T) predicate) {
-    assert(predicate != null);
+    assert(() {
+      if (predicate == null) throw ArgumentError("predicate can't be null");
+      return true;
+    }());
     if (!isEmpty()) {
       final i = listIterator(size);
       while (i.hasPrevious()) {
@@ -29,9 +36,12 @@ abstract class KListExtensionsMixin<T> implements KListExtension<T>, KList<T> {
 
   @override
   T elementAtOrElse(int index, T defaultValue(int index)) {
-    if (index == null) throw ArgumentError("index can't be null");
-    if (defaultValue == null)
-      throw ArgumentError("defaultValue function can't be null");
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      if (defaultValue == null)
+        throw ArgumentError("defaultValue function can't be null");
+      return true;
+    }());
     return index >= 0 && index <= lastIndex ? get(index) : defaultValue(index);
   }
 
@@ -54,6 +64,10 @@ abstract class KListExtensionsMixin<T> implements KListExtension<T>, KList<T> {
 
   @override
   R foldRight<R>(R initial, R Function(T, R acc) operation) {
+    assert(() {
+      if (operation == null) throw ArgumentError("operation can't be null");
+      return true;
+    }());
     if (isEmpty()) return initial;
 
     var accumulator = initial;
@@ -66,6 +80,10 @@ abstract class KListExtensionsMixin<T> implements KListExtension<T>, KList<T> {
 
   @override
   R foldRightIndexed<R>(R initial, R Function(int index, T, R acc) operation) {
+    assert(() {
+      if (operation == null) throw ArgumentError("operation can't be null");
+      return true;
+    }());
     if (isEmpty()) return initial;
 
     var accumulator = initial;
@@ -78,9 +96,12 @@ abstract class KListExtensionsMixin<T> implements KListExtension<T>, KList<T> {
 
   @override
   T getOrElse(int index, T Function(int) defaultValue) {
-    if (index == null) throw ArgumentError("index can't be null");
-    if (defaultValue == null)
-      throw ArgumentError("default value function can't be null");
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      if (defaultValue == null)
+        throw ArgumentError("default value function can't be null");
+      return true;
+    }());
     return (index >= 0 && index <= lastIndex)
         ? get(index)
         : defaultValue(index);
@@ -88,7 +109,10 @@ abstract class KListExtensionsMixin<T> implements KListExtension<T>, KList<T> {
 
   @override
   T getOrNull(int index) {
-    if (index == null) throw ArgumentError("index can't be null");
+    assert(() {
+      if (index == null) throw ArgumentError("index can't be null");
+      return true;
+    }());
     return index >= 0 && index <= lastIndex ? get(index) : null;
   }
 
@@ -118,6 +142,10 @@ abstract class KListExtensionsMixin<T> implements KListExtension<T>, KList<T> {
 
   @override
   S reduceRight<S>(S Function(T, S acc) operation) {
+    assert(() {
+      if (operation == null) throw ArgumentError("operation can't be null");
+      return true;
+    }());
     final i = listIterator(size);
     if (!i.hasPrevious()) {
       throw UnimplementedError("Empty list can't be reduced.");
@@ -131,6 +159,10 @@ abstract class KListExtensionsMixin<T> implements KListExtension<T>, KList<T> {
 
   @override
   S reduceRightIndexed<S>(S Function(int index, T, S acc) operation) {
+    assert(() {
+      if (operation == null) throw ArgumentError("operation can't be null");
+      return true;
+    }());
     final i = listIterator(size);
     if (!i.hasPrevious()) {
       throw UnimplementedError("Empty list can't be reduced.");
@@ -144,6 +176,10 @@ abstract class KListExtensionsMixin<T> implements KListExtension<T>, KList<T> {
 
   @override
   KList<T> slice(KIterable<int> indices) {
+    assert(() {
+      if (indices == null) throw ArgumentError("indices can't be null");
+      return true;
+    }());
     if (indices.count() == 0) {
       return emptyList<T>();
     }

--- a/lib/src/extension/list_mutable_extension_mixin.dart
+++ b/lib/src/extension/list_mutable_extension_mixin.dart
@@ -24,6 +24,10 @@ abstract class KMutableListExtensionsMixin<T>
 
   @override
   void sortBy<R extends Comparable<R>>(R Function(T) selector) {
+    assert(() {
+      if (selector == null) throw ArgumentError("selector can't be null");
+      return true;
+    }());
     if (size > 1) {
       sortWith(compareBy(selector));
     }
@@ -31,6 +35,10 @@ abstract class KMutableListExtensionsMixin<T>
 
   @override
   void sortByDescending<R extends Comparable<R>>(R Function(T) selector) {
+    assert(() {
+      if (selector == null) throw ArgumentError("selector can't be null");
+      return true;
+    }());
     if (size > 1) {
       sortWith(compareByDescending(selector));
     }
@@ -38,6 +46,10 @@ abstract class KMutableListExtensionsMixin<T>
 
   @override
   void sortWith(Comparator<T> comparator) {
+    assert(() {
+      if (comparator == null) throw ArgumentError("comparator can't be null");
+      return true;
+    }());
     list.sort(comparator);
   }
 

--- a/lib/src/extension/map_extensions_mixin.dart
+++ b/lib/src/extension/map_extensions_mixin.dart
@@ -5,6 +5,11 @@ abstract class KMapExtensionsMixin<K, V>
     implements KMapExtension<K, V>, KMap<K, V> {
   @override
   V getOrElse(K key, V Function() defaultValue) {
+    assert(() {
+      if (defaultValue == null)
+        throw ArgumentError("defaultValue can't be null");
+      return true;
+    }());
     return get(key) ?? defaultValue();
   }
 
@@ -56,6 +61,10 @@ abstract class KMapExtensionsMixin<K, V>
 
   @override
   KMap<K, V> plus(KMap<K, V> map) {
+    assert(() {
+      if (map == null) throw ArgumentError("map can't be null");
+      return true;
+    }());
     return toMutableMap()..putAll(map);
   }
 

--- a/lib/src/extension/map_mutable_extensions_mixin.dart
+++ b/lib/src/extension/map_mutable_extensions_mixin.dart
@@ -5,6 +5,11 @@ abstract class KMutableMapExtensionsMixin<K, V>
     implements KMutableMapExtension<K, V>, KMutableMap<K, V> {
   @override
   V getOrPut(K key, V Function() defaultValue) {
+    assert(() {
+      if (defaultValue == null)
+        throw ArgumentError("defaultValue can't be null");
+      return true;
+    }());
     final value = get(key);
     if (value != null) return value;
     final answer = defaultValue();
@@ -16,6 +21,10 @@ abstract class KMutableMapExtensionsMixin<K, V>
 
   @override
   void putAllPairs(KIterable<KPair<K, V>> pairs) {
+    assert(() {
+      if (pairs == null) throw ArgumentError("pairs can't be null");
+      return true;
+    }());
     for (var value in pairs.iter) {
       put(value.first, value.second);
     }

--- a/tool/run_coverage_locally.sh
+++ b/tool/run_coverage_locally.sh
@@ -5,7 +5,7 @@
   pub global activate coverage
 }
 pub global run coverage:collect_coverage --port=8111 -o out/coverage/coverage.json --resume-isolates --wait-paused &
-dart --observe=8111 test/dart_kollection_test.dart
+dart --observe=8111 --enable-asserts test/dart_kollection_test.dart
 pub global run coverage:format_coverage --packages=.packages --report-on lib --in out/coverage/coverage.json --out out/coverage/lcov.info --lcov
 genhtml -o out/coverage/html out/coverage/lcov.info
 echo "open coverage report $PWD/out/coverage/html/index.html"


### PR DESCRIPTION
Prevent errors early and give useful errors for developers.
Moved argument checks inside assert blocks so they don't get executed in production