### PR TITLE
Adds all tests for DartList

### DIFF
--- a/lib/src/collection/list_empty.dart
+++ b/lib/src/collection/list_empty.dart
@@ -77,7 +77,8 @@ class EmptyList<T>
       return true;
     }());
     if (fromIndex == 0 && toIndex == 0) return this;
-    throw IndexOutOfBoundsException("fromIndex: $fromIndex, toIndex: $toIndex");
+    throw IndexOutOfBoundsException(
+        "fromIndex: $fromIndex, toIndex: $toIndex, size: $size");
   }
 
   @override

--- a/lib/src/collection/list_mutable.dart
+++ b/lib/src/collection/list_mutable.dart
@@ -128,6 +128,9 @@ class DartMutableList<T>
       if (index == null) throw ArgumentError("index can't be null");
       return true;
     }());
+    if (index < 0 || index >= size) {
+      throw IndexOutOfBoundsException("index: $index, size: $size");
+    }
     return _list.removeAt(index);
   }
 

--- a/test/collection/collection_mutable_test.dart
+++ b/test/collection/collection_mutable_test.dart
@@ -52,6 +52,33 @@ void testCollection(
     });
   });
 
+  group("removeAll", () {
+    test("remove items", () {
+      final list = mutableCollectionOf(["a", "b", "c", "d"]);
+      list.removeAll(listOf(["b", "c"]));
+      expect(list, mutableCollectionOf(["a", "d"]));
+    });
+    test("elements can't be null", () {
+      final e =
+          catchException<ArgumentError>(() => mutableListOf().removeAll(null));
+      expect(e.message, allOf(contains("null"), contains("elements")));
+    });
+  });
+
+  group("retainAll", () {
+    test("retain items", () {
+      final list = mutableCollectionOf(["a", "b", "c", "d", "a", "b"]);
+      list.retainAll(listOf(["b", "c"]));
+      expect(list, mutableCollectionOf(["b", "c", "b"]));
+    });
+
+    test("elements can't be null", () {
+      final e =
+          catchException<ArgumentError>(() => mutableListOf().retainAll(null));
+      expect(e.message, allOf(contains("null"), contains("elements")));
+    });
+  });
+
   group("toString", () {
     test("recursive list with self reference prints nicely", () {
       final self = mutableCollectionOf<dynamic>([]);

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -677,6 +677,20 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
     });
   });
 
+  group("indexOf", () {
+    test("returns index", () {
+      final iterable = iterableOf(["a", "b", "c", "b"]);
+      var found = iterable.indexOf("b");
+      if (iterable.count() == 4) {
+        // ordered list
+        expect(found, 1);
+      } else {
+        // set, position is unknown
+        expect(found, isNot(-1));
+      }
+    });
+  });
+
   group("intersect", () {
     test("remove one item", () {
       var a = iterableOf(["paul", "john", "max", "lisa"]);
@@ -733,6 +747,20 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
 
     test("finds nothing throws", () {
       expect(iterableOf<String>(["a"]).lastOrNull((it) => it == "b"), isNull);
+    });
+  });
+
+  group("lastIndexOf", () {
+    test("returns last index", () {
+      final iterable = iterableOf(["a", "b", "c", "b"]);
+      var found = iterable.lastIndexOf("b");
+      if (iterable.count() == 4) {
+        // ordered list
+        expect(found, 3);
+      } else {
+        // set, position is unknown
+        expect(found, isNot(-1));
+      }
     });
   });
 

--- a/test/collection/list_empty_test.dart
+++ b/test/collection/list_empty_test.dart
@@ -52,6 +52,15 @@ void main() {
       expect(empty.indexOf(null), equals(-1));
     });
 
+    test("lastIndexOf always returns -1", () {
+      final empty = emptyList();
+
+      expect(empty.lastIndexOf(""), equals(-1));
+      expect(empty.lastIndexOf([]), equals(-1));
+      expect(empty.lastIndexOf(0), equals(-1));
+      expect(empty.lastIndexOf(null), equals(-1));
+    });
+
     test("is equals to another empty list", () {
       final empty0 = emptyList();
       final empty1 = emptyList();
@@ -117,6 +126,35 @@ void main() {
       ArgumentError e = catchException(() => emptyList().listIterator(null));
       expect(e.message, contains("index"));
       expect(e.message, contains("null"));
+    });
+
+    test("[] get operator", () {
+      final list = emptyList();
+
+      final e0 = catchException<IndexOutOfBoundsException>(() => list[0]);
+      expect(e0.message, contains("doesn't contain element at index 0"));
+      final e1 = catchException<IndexOutOfBoundsException>(() => list[-1]);
+      expect(e1.message, contains("doesn't contain element at index -1"));
+      final e2 = catchException<IndexOutOfBoundsException>(() => list[3]);
+      expect(e2.message, contains("doesn't contain element at index 3"));
+
+      final e3 = catchException<ArgumentError>(() => list[null]);
+      expect(e3.message, allOf(contains("null"), contains("index")));
+    });
+
+    test("toString prints empty list", () {
+      expect(emptyList().toString(), "[]");
+    });
+
+    test("listIterator doesn't iterate", () {
+      final i = emptyList().listIterator();
+      expect(i.hasNext(), false);
+      expect(i.hasPrevious(), false);
+      expect(i.nextIndex(), 0);
+      expect(i.previousIndex(), -1);
+      expect(
+          () => i.previous(), throwsA(TypeMatcher<NoSuchElementException>()));
+      expect(() => i.next(), throwsA(TypeMatcher<NoSuchElementException>()));
     });
   });
 }

--- a/test/collection/list_mutable_extensions_test.dart
+++ b/test/collection/list_mutable_extensions_test.dart
@@ -4,6 +4,21 @@ import 'package:test/test.dart';
 import '../test/assert_dart.dart';
 
 void main() {
+  group("clear", () {
+    test("clear list", () {
+      final list = mutableListOf(["a", "b", "c"]);
+      expect(list.size, 3);
+      list.clear();
+      expect(list.size, 0);
+    });
+    test("clear empty list", () {
+      final list = mutableListOf();
+      expect(list.size, 0);
+      list.clear();
+      expect(list.size, 0);
+    });
+  });
+
   group('fill', () {
     test("replace all elements", () {
       final list = mutableListOf(["a", "b", "c"]);
@@ -15,6 +30,34 @@ void main() {
       final list = mutableListOf<String>([]);
       list.fill("x");
       expect(list, emptyList());
+    });
+  });
+
+  group("removeAt", () {
+    test("index can't be null", () {
+      final e =
+          catchException<ArgumentError>(() => mutableListOf().removeAt(null));
+      expect(e.message, allOf(contains("null"), contains("index")));
+    });
+
+    test("removes item at index", () {
+      final list = mutableListOf(["a", "b", "c"]);
+      list.removeAt(1);
+      expect(list, listOf(["a", "c"]));
+    });
+
+    test("removeAt throw for indexes greater size", () {
+      final list = mutableListOf(["a", "b", "c"]);
+      final e =
+          catchException<IndexOutOfBoundsException>(() => list.removeAt(-1));
+      expect(e.message, allOf(contains("3"), contains("")));
+    });
+
+    test("removeAt throw for indexes below 0", () {
+      final list = mutableListOf(["a", "b", "c"]);
+      final e =
+          catchException<IndexOutOfBoundsException>(() => list.removeAt(-1));
+      expect(e.message, allOf(contains("-1"), contains("")));
     });
   });
 

--- a/test/collection/list_mutable_test.dart
+++ b/test/collection/list_mutable_test.dart
@@ -192,5 +192,11 @@ void main() {
           () => mutableListOf().addAllAt(0, null));
       expect(e.message, allOf(contains("null"), contains("elements")));
     });
+
+    test("listIterator requires int as index", () {
+      final e = catchException<ArgumentError>(
+          () => mutableListOf(["a", "b", "c"]).listIterator(null));
+      expect(e.message, allOf(contains("null"), contains("index")));
+    });
   });
 }


### PR DESCRIPTION
- `KMutableList.removeAt` now throws `IndexOutOfBoundsException` for invalid indexes