### PR TITLE
Fix stack overflow for when calling KList.single

### DIFF
--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -1067,7 +1067,6 @@ abstract class KIterableExtensionsMixin<T>
   @override
   T single([bool Function(T) predicate]) {
     if (predicate == null) {
-      if (this is KList) return (this as KList).single();
       var i = iterator();
       if (!i.hasNext()) {
         throw NoSuchElementException("Collection is empty.");
@@ -1098,18 +1097,13 @@ abstract class KIterableExtensionsMixin<T>
 
   T singleOrNull([bool Function(T) predicate]) {
     if (predicate == null) {
-      if (this is KList) {
-        final list = (this as KList);
-        return list.size == 1 ? list.get(0) : null;
-      } else {
-        final i = iterator();
-        if (!i.hasNext()) return null;
-        final single = i.next();
-        if (i.hasNext()) {
-          return null;
-        }
-        return single;
+      final i = iterator();
+      if (!i.hasNext()) return null;
+      final single = i.next();
+      if (i.hasNext()) {
+        return null;
       }
+      return single;
     } else {
       T single = null;
       var found = false;

--- a/lib/src/extension/list_extension_mixin.dart
+++ b/lib/src/extension/list_extension_mixin.dart
@@ -175,6 +175,60 @@ abstract class KListExtensionsMixin<T> implements KListExtension<T>, KList<T> {
   }
 
   @override
+  T single([bool Function(T) predicate]) {
+    if (predicate == null) {
+      switch (size) {
+        case 0:
+          throw NoSuchElementException("List is empty");
+        case 1:
+          return get(0);
+        default:
+          throw ArgumentError("List has more than one element.");
+      }
+    } else {
+      T single = null;
+      var found = false;
+      for (final element in iter) {
+        if (predicate(element)) {
+          if (found)
+            throw ArgumentError(
+                "Collection contains more than one matching element.");
+          single = element;
+          found = true;
+        }
+      }
+      if (!found) {
+        throw NoSuchElementException(
+            "Collection contains no element matching the predicate.");
+      }
+      return single;
+    }
+  }
+
+  @override
+  T singleOrNull([bool Function(T) predicate]) {
+    if (predicate == null) {
+      if (size == 1) {
+        return get(0);
+      } else {
+        return null;
+      }
+    } else {
+      T single = null;
+      var found = false;
+      for (final element in iter) {
+        if (predicate(element)) {
+          if (found) return null;
+          single = element;
+          found = true;
+        }
+      }
+      if (!found) return null;
+      return single;
+    }
+  }
+
+  @override
   KList<T> slice(KIterable<int> indices) {
     assert(() {
       if (indices == null) throw ArgumentError("indices can't be null");

--- a/lib/src/k_iterable.dart
+++ b/lib/src/k_iterable.dart
@@ -570,7 +570,7 @@ abstract class KIterableExtension<T> {
   KList<T> reversed();
 
   /**
-   * Returns the single element matching the given [predicate], or throws exception if there is no or more than one matching element.
+   * Returns the single element matching the given [predicate], or throws an exception if the list is empty or has more than one element.
    */
   @nonNull
   T single([bool Function(T) predicate]);

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -1140,6 +1140,66 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
     });
   });
 
+  group("single", () {
+    test("single", () {
+      expect(iterableOf([1]).single(), 1);
+    });
+    test("single throws when list has more elements", () {
+      final e =
+          catchException<ArgumentError>(() => iterableOf([1, 2]).single());
+      expect(e.message, contains("has more than one element"));
+    });
+    test("single throws for empty iterables", () {
+      final e = catchException<NoSuchElementException>(
+          () => emptyIterable().single());
+      expect(e.message, contains("is empty"));
+    });
+    test("single with predicate finds item", () {
+      final found = iterableOf(["paul", "john", "max", "lisa"])
+          .single((it) => it.contains("x"));
+      expect(found, "max");
+    });
+    test("single with predicate without match", () {
+      final e = catchException<NoSuchElementException>(() =>
+          iterableOf(["paul", "john", "max", "lisa"])
+              .single((it) => it.contains("y")));
+      expect(e.message, contains("no element matching the predicate"));
+    });
+    test("single with predicate multiple matches", () {
+      final e = catchException<ArgumentError>(() =>
+          iterableOf(["paul", "john", "max", "lisa"])
+              .single((it) => it.contains("l")));
+      expect(e.message, contains("more than one matching element"));
+    });
+  });
+
+  group("singleOrNull", () {
+    test("singleOrNull", () {
+      expect(iterableOf([1]).singleOrNull(), 1);
+    });
+    test("singleOrNull on multiple iterable returns null", () {
+      expect(iterableOf([1, 2]).singleOrNull(), null);
+    });
+    test("singleOrNull on empty iterable returns null", () {
+      expect(emptyIterable().singleOrNull(), null);
+    });
+    test("singleOrNull with predicate finds item", () {
+      final found = iterableOf(["paul", "john", "max", "lisa"])
+          .singleOrNull((it) => it.contains("x"));
+      expect(found, "max");
+    });
+    test("singleOrNull with predicate without match returns null", () {
+      final result = iterableOf(["paul", "john", "max", "lisa"])
+          .singleOrNull((it) => it.contains("y"));
+      expect(result, null);
+    });
+    test("singleOrNull with predicate multiple matches returns null", () {
+      final result = iterableOf(["paul", "john", "max", "lisa"])
+          .singleOrNull((it) => it.contains("l"));
+      expect(result, null);
+    });
+  });
+
   group("sort", () {
     test("sort", () {
       final result = iterableOf([4, 2, 3, 1]).sorted();


### PR DESCRIPTION
Adds faster routes for `KLists.single()` without allocating a `KIterator`