### PR TITLE
Remove non compiling APIs due to a dart-lang bug

### DIFF
--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -89,7 +89,7 @@ abstract class KIterableExtensionsMixin<T>
     return associateWithTo(linkedMapOf<T, V>(), valueSelector);
   }
 
-  @override
+  // TODO add @override again
   M associateWithTo<V, M extends KMutableMap<T, V>>(
       M destination, V Function(T) valueSelector) {
     assert(() {
@@ -285,7 +285,7 @@ abstract class KIterableExtensionsMixin<T>
     return list;
   }
 
-  @override
+  // TODO add @override again
   C filterIndexedTo<C extends KMutableCollection<T>>(
       C destination, bool Function(int index, T) predicate) {
     assert(() {
@@ -328,7 +328,7 @@ abstract class KIterableExtensionsMixin<T>
     return list;
   }
 
-  @override
+  // TODO add @override again
   C filterNotNullTo<C extends KMutableCollection<T>>(C destination) {
     for (final element in iter) {
       if (element != null) {
@@ -338,7 +338,7 @@ abstract class KIterableExtensionsMixin<T>
     return destination;
   }
 
-  @override
+  // TODO add @override again
   C filterNotTo<C extends KMutableCollection<T>>(
       C destination, bool Function(T) predicate) {
     assert(() {
@@ -354,7 +354,7 @@ abstract class KIterableExtensionsMixin<T>
     return destination;
   }
 
-  @override
+  // TODO add @override again
   C filterTo<C extends KMutableCollection<T>>(
       C destination, bool Function(T) predicate) {
     assert(() {
@@ -518,7 +518,7 @@ abstract class KIterableExtensionsMixin<T>
     return groups;
   }
 
-  @override
+  // TODO add @override again
   M groupByTo<K, M extends KMutableMap<K, KMutableList<T>>>(
       M destination, K Function(T) keySelector) {
     assert(() {

--- a/lib/src/extension/map_extensions_mixin.dart
+++ b/lib/src/extension/map_extensions_mixin.dart
@@ -34,7 +34,7 @@ abstract class KMapExtensionsMixin<K, V>
     return mapped;
   }
 
-  @override
+  // TODO add @override again
   M mapKeysTo<R, M extends KMutableMap<R, V>>(
       M destination, R Function(KMapEntry<K, V> entry) transform) {
     return entries.associateByTo(destination, transform, (it) => it.value);
@@ -46,7 +46,7 @@ abstract class KMapExtensionsMixin<K, V>
     return mapped;
   }
 
-  @override
+  // TODO add @override again
   M mapValuesTo<R, M extends KMutableMap<K, R>>(
       M destination, R Function(KMapEntry<K, V> entry) transform) {
     return entries.associateByTo(destination, (it) => it.key, transform);

--- a/lib/src/k_iterable.dart
+++ b/lib/src/k_iterable.dart
@@ -102,8 +102,9 @@ abstract class KIterableExtension<T> {
    *
    * If any two elements are equal, the last one overwrites the former value in the map.
    */
-  M associateWithTo<V, M extends KMutableMap<T, V>>(
-      M destination, V Function(T) valueSelector);
+  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  // M associateWithTo<V, M extends KMutableMap<T, V>>(
+  //     M destination, V Function(T) valueSelector);
 
   /**
    * Returns an average value produced by [selector] function applied to each element in the collection.
@@ -204,8 +205,9 @@ abstract class KIterableExtension<T> {
    * @param [predicate] function that takes the index of an element and the element itself
    * and returns the result of predicate evaluation on the element.
    */
-  C filterIndexedTo<C extends KMutableCollection<T>>(
-      C destination, bool Function(int index, T) predicate);
+  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  // C filterIndexedTo<C extends KMutableCollection<T>>(
+  //     C destination, bool Function(int index, T) predicate);
 
   /**
    * Returns a list containing all elements that are instances of specified type parameter R.
@@ -225,19 +227,22 @@ abstract class KIterableExtension<T> {
   /**
    * Appends all elements that are not `null` to the given [destination].
    */
-  C filterNotNullTo<C extends KMutableCollection<T>>(C destination);
+  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  // C filterNotNullTo<C extends KMutableCollection<T>>(C destination);
 
   /**
    * Appends all elements not matching the given [predicate] to the given [destination].
    */
-  C filterNotTo<C extends KMutableCollection<T>>(
-      C destination, bool Function(T) predicate);
+  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  // C filterNotTo<C extends KMutableCollection<T>>(
+  //     C destination, bool Function(T) predicate);
 
   /**
    * Appends all elements matching the given [predicate] to the given [destination].
    */
-  C filterTo<C extends KMutableCollection<T>>(
-      C destination, bool Function(T) predicate);
+  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  // C filterTo<C extends KMutableCollection<T>>(
+  //     C destination, bool Function(T) predicate);
 
   /**
    * Returns the first element matching the given [predicate], or `null` if no such element was found.
@@ -327,8 +332,9 @@ abstract class KIterableExtension<T> {
    *
    * @return The [destination] map.
    */
-  M groupByTo<K, M extends KMutableMap<K, KMutableList<T>>>(
-      M destination, K Function(T) keySelector);
+  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  // M groupByTo<K, M extends KMutableMap<K, KMutableList<T>>>(
+  //     M destination, K Function(T) keySelector);
 
   /**
    * Groups values returned by the [valueTransform] function applied to each element of the original collection

--- a/lib/src/k_map.dart
+++ b/lib/src/k_map.dart
@@ -139,8 +139,9 @@ abstract class KMapExtension<K, V> {
    * In case if any two entries are mapped to the equal keys, the value of the latter one will overwrite
    * the value associated with the former one.
    */
-  M mapKeysTo<R, M extends KMutableMap<R, V>>(
-      M destination, R Function(KMapEntry<K, V> entry) transform);
+  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  // M mapKeysTo<R, M extends KMutableMap<R, V>>(
+  //     M destination, R Function(KMapEntry<K, V> entry) transform);
 
   /**
    * Returns a new map with entries having the keys of this map and the values obtained by applying the [transform]
@@ -154,8 +155,9 @@ abstract class KMapExtension<K, V> {
    * Populates the given [destination] map with entries having the keys of this map and the values obtained
    * by applying the [transform] function to each entry in this [Map].
    */
-  M mapValuesTo<R, M extends KMutableMap<K, R>>(
-      M destination, R Function(KMapEntry<K, V> entry) transform);
+  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  // M mapValuesTo<R, M extends KMutableMap<K, R>>(
+  //     M destination, R Function(KMapEntry<K, V> entry) transform);
 
   /**
    * Returns a map containing all entries of the original map except the entry with the given [key].

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -503,15 +503,6 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
     });
   });
 
-  group("filterTo", () {
-    test("filterTo doesn't allow null as destination", () {
-      final list = emptyIterable<String>();
-      var e =
-          catchException<ArgumentError>(() => list.filterTo(null, (_) => true));
-      expect(e.message, allOf(contains("null"), contains("destination")));
-    });
-  });
-
   group("filterNot", () {
     test("filterNot", () {
       final iterable = iterableOf(["paul", "peter", "john", "lisa"]);
@@ -523,13 +514,6 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
       final list = emptyIterable<String>();
       var e = catchException<ArgumentError>(() => list.filterNot(null));
       expect(e.message, allOf(contains("null"), contains("predicate")));
-    });
-
-    test("filterNotTo doesn't allow null as destination", () {
-      final list = emptyIterable<String>();
-      var e = catchException<ArgumentError>(
-          () => list.filterNotTo(null, (_) => true));
-      expect(e.message, allOf(contains("null"), contains("destination")));
     });
   });
 
@@ -798,13 +782,6 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
       expect(e.message, allOf(contains("null"), contains("keySelector")));
     });
 
-    test("groupByTo doesn't allow null as destination", () {
-      final iterable = iterableOf([1, 2, 3]);
-      var e = catchException<ArgumentError>(
-          () => iterable.groupByTo(null, (it) => it));
-      expect(e.message, allOf(contains("null"), contains("destination")));
-    });
-
     test("groupByTransform doesn't allow null as keySelector", () {
       final iterable = iterableOf([1, 2, 3]);
       var e = catchException<ArgumentError>(
@@ -817,13 +794,6 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
       var e = catchException<ArgumentError>(
           () => iterable.groupByTransform((it) => it, null));
       expect(e.message, allOf(contains("null"), contains("valueTransform")));
-    });
-
-    test("groupByTo doesn't allow null as destination", () {
-      final iterable = iterableOf([1, 2, 3]);
-      var e = catchException<ArgumentError>(
-          () => iterable.groupByTo(null, (it) => it));
-      expect(e.message, allOf(contains("null"), contains("destination")));
     });
 
     test("groupByToTransform doesn't allow null as destination", () {


### PR DESCRIPTION
Bug https://github.com/dart-lang/sdk/issues/35518 prevents calls from external classes to those methods. the generic bound type is not correctly passed to the method resulting in a wrong inferred argument bounds violation.

Removed extensions:
- `KIterable<T>.associateWithTo`
- `Kiterable<T>.filterTo`
- `KIterable<T>.filterIndexedTo`
- `KIterable<T>.filterNotTo`
- `KIterable<T>.filterNotNullTo`
- `KIterable<T>.groupByTo`
- `KMap<T>.mapKeysTo`
- `KMap<T>.mapValuesTo`

Other `..To` extensions like `KIterable<T>.flatMapTo` aren't affected. They don't have a generic type of the mixin in their generic type bounds.