### PR TITLE
Revive -To methods

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -78,7 +78,6 @@ linter:
     - type_init_formals
     - unnecessary_brace_in_string_interps
     - unnecessary_getters_setters
-    - unnecessary_lambdas
     - unnecessary_new # under review (see #1068)
     - unnecessary_null_aware_assignments
     - unnecessary_null_in_if_null_operators

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -74,7 +74,6 @@ linter:
     - sort_constructors_first
     - sort_unnamed_constructors_first
     - super_goes_last
-    - test_types_in_equals
     - type_annotate_public_apis
     - type_init_formals
     - unnecessary_brace_in_string_interps

--- a/lib/src/collection/list_mutable.dart
+++ b/lib/src/collection/list_mutable.dart
@@ -1,6 +1,7 @@
 import 'package:dart_kollection/dart_kollection.dart';
 import 'package:dart_kollection/src/collection/iterator.dart';
 import 'package:dart_kollection/src/extension/collection_extension_mixin.dart';
+import 'package:dart_kollection/src/extension/collection_mutable_extension_mixin.dart';
 import 'package:dart_kollection/src/extension/iterable_extension_mixin.dart';
 import 'package:dart_kollection/src/extension/iterable_mutable_extension_mixin.dart';
 import 'package:dart_kollection/src/extension/list_extension_mixin.dart';
@@ -15,6 +16,7 @@ class DartMutableList<T>
         KIterableExtensionsMixin<T>,
         KCollectionExtensionMixin<T>,
         KMutableIterableExtensionsMixin<T>,
+        KMutableCollectionExtensionMixin<T>,
         KListExtensionsMixin<T>,
         KMutableListExtensionsMixin<T>
     implements KMutableList<T> {

--- a/lib/src/collection/set.dart
+++ b/lib/src/collection/set.dart
@@ -55,8 +55,9 @@ class DartSet<T>
     if (other.hashCode != hashCode) return false;
     if (other is KSet<T>) {
       return containsAll(other);
+    } else {
+      return other.containsAll(this);
     }
-    return false;
   }
 }
 

--- a/lib/src/collection/set.dart
+++ b/lib/src/collection/set.dart
@@ -56,7 +56,7 @@ class DartSet<T>
     if (other is KSet<T>) {
       return containsAll(other);
     } else {
-      return other.containsAll(this);
+      return (other as KSet).containsAll(this);
     }
   }
 }

--- a/lib/src/collection/set_mutable.dart
+++ b/lib/src/collection/set_mutable.dart
@@ -64,7 +64,7 @@ class DartMutableSet<T>
     if (other is KSet<T>) {
       return containsAll(other);
     } else {
-      return other.containsAll(this);
+      return (other as KSet).containsAll(this);
     }
   }
 

--- a/lib/src/collection/set_mutable.dart
+++ b/lib/src/collection/set_mutable.dart
@@ -63,8 +63,9 @@ class DartMutableSet<T>
     if (other.hashCode != hashCode) return false;
     if (other is KSet<T>) {
       return containsAll(other);
+    } else {
+      return other.containsAll(this);
     }
-    return false;
   }
 
   @override

--- a/lib/src/extension/collection_mutable_extension_mixin.dart
+++ b/lib/src/extension/collection_mutable_extension_mixin.dart
@@ -1,0 +1,4 @@
+import 'package:dart_kollection/dart_kollection.dart';
+
+abstract class KMutableCollectionExtensionMixin<T>
+    implements KMutableCollectionExtension<T>, KMutableCollection<T> {}

--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -287,22 +287,33 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   KList<T> filter(bool Function(T) predicate) {
-    final list = filterTo(mutableListOf<T>(), predicate);
+    final filtered = filterTo(mutableListOf<T>(), predicate);
     // TODO ping dort-lang/sdk team to check type bug
     // When in single line: type 'DartMutableList<String>' is not a subtype of type 'Null'
-    return list;
+    return filtered;
   }
 
   @override
   KList<T> filterIndexed(bool Function(int index, T) predicate) {
-    final list = filterIndexedTo(mutableListOf<T>(), predicate);
-    return list;
+    final filtered = filterIndexedTo(mutableListOf<T>(), predicate);
+    // TODO ping dort-lang/sdk team to check type bug
+    // When in single line: type 'DartMutableList<String>' is not a subtype of type 'Null'
+    return filtered;
   }
 
-  C filterIndexedTo<C extends KMutableCollection<T>>(
+  @override
+  C filterIndexedTo<C extends KMutableCollection<dynamic>>(
       C destination, bool Function(int index, T) predicate) {
     assert(() {
+      if (destination == null) throw ArgumentError("destination can't be null");
       if (predicate == null) throw ArgumentError("predicate can't be null");
+      if (mutableListOf<T>() is! C)
+        throw ArgumentError(
+            "filterIndexedTo destination has wrong type parameters."
+            "\nExpected: KMutableCollection<$T>, Actual: ${destination.runtimeType}"
+            "\ndestination (${destination.runtimeType}) entries aren't subtype of "
+            "map ($runtimeType) entries. Entries can't be copied to destination."
+            "\n\n$kBug35518GenericTypeError");
       return true;
     }());
     var i = 0;

--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -89,7 +89,8 @@ abstract class KIterableExtensionsMixin<T>
 
   @override
   KMap<T, V> associateWith<V>(V Function(T) valueSelector) {
-    return associateWithTo(linkedMapOf<T, V>(), valueSelector);
+    final associated = associateWithTo(linkedMapOf<T, V>(), valueSelector);
+    return associated;
   }
 
   @override
@@ -103,8 +104,8 @@ abstract class KIterableExtensionsMixin<T>
         throw ArgumentError(
             "associateWithTo destination has wrong type parameters."
             "\nExpected: KMutableMap<$T, $V>, Actual: ${destination.runtimeType}"
-            "\ndestination (${destination.runtimeType}) entries aren't subtype of "
-            "map ($runtimeType) entries. Entries can't be copied to destination."
+            "\ndestination (${destination.runtimeType}) items aren't subtype of "
+            "$runtimeType items. Items can't be copied to destination."
             "\n\n$kBug35518GenericTypeError");
       return true;
     }());

--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -576,7 +576,7 @@ abstract class KIterableExtensionsMixin<T>
     }());
     for (final element in iter) {
       final key = keySelector(element);
-      final list = destination.getOrPut(key, mutableListOf);
+      final list = destination.getOrPut(key, () => mutableListOf<T>());
       list.add(element);
     }
     return destination;
@@ -594,7 +594,7 @@ abstract class KIterableExtensionsMixin<T>
     }());
     for (final element in iter) {
       final key = keySelector(element);
-      final list = destination.getOrPut(key, mutableListOf);
+      final list = destination.getOrPut(key, () => mutableListOf<V>());
       list.add(valueTransform(element));
     }
     return destination;

--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -361,11 +361,18 @@ abstract class KIterableExtensionsMixin<T>
     return destination;
   }
 
-  C filterNotTo<C extends KMutableCollection<T>>(
+  @override
+  C filterNotTo<C extends KMutableCollection<dynamic>>(
       C destination, bool Function(T) predicate) {
     assert(() {
       if (predicate == null) throw ArgumentError("predicate can't be null");
       if (destination == null) throw ArgumentError("destination can't be null");
+      if (mutableListOf<T>() is! C)
+        throw ArgumentError("filterNotTo destination has wrong type parameters."
+            "\nExpected: KMutableCollection<$T>, Actual: ${destination.runtimeType}"
+            "\ndestination (${destination.runtimeType}) entries aren't subtype of "
+            "map ($runtimeType) entries. Entries can't be copied to destination."
+            "\n\n$kBug35518GenericTypeError");
       return true;
     }());
     for (final element in iter) {

--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -376,11 +376,18 @@ abstract class KIterableExtensionsMixin<T>
     return destination;
   }
 
-  C filterTo<C extends KMutableCollection<T>>(
+  @override
+  C filterTo<C extends KMutableCollection<dynamic>>(
       C destination, bool Function(T) predicate) {
     assert(() {
       if (predicate == null) throw ArgumentError("predicate can't be null");
       if (destination == null) throw ArgumentError("destination can't be null");
+      if (mutableListOf<T>() is! C)
+        throw ArgumentError("filterTo destination has wrong type parameters."
+            "\nExpected: KMutableCollection<$T>, Actual: ${destination.runtimeType}"
+            "\ndestination (${destination.runtimeType}) entries aren't subtype of "
+            "map ($runtimeType) entries. Entries can't be copied to destination."
+            "\n\n$kBug35518GenericTypeError");
       return true;
     }());
     for (final element in iter) {

--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:dart_kollection/dart_kollection.dart';
 import 'package:dart_kollection/src/comparisons.dart';
 import 'package:dart_kollection/src/k_iterable.dart';
+import 'package:dart_kollection/src/util/errors.dart';
 
 abstract class KIterableExtensionsMixin<T>
     implements KIterableExtension<T>, KIterable<T> {
@@ -91,11 +92,20 @@ abstract class KIterableExtensionsMixin<T>
     return associateWithTo(linkedMapOf<T, V>(), valueSelector);
   }
 
-  M associateWithTo<V, M extends KMutableMap<T, V>>(
+  @override
+  M associateWithTo<V, M extends KMutableMap<dynamic, dynamic>>(
       M destination, V Function(T) valueSelector) {
     assert(() {
+      if (destination == null) throw ArgumentError("destination can't be null");
       if (valueSelector == null)
         throw ArgumentError("valueSelector can't be null");
+      if (mutableMapOf<T, V>() is! M)
+        throw ArgumentError(
+            "associateWithTo destination has wrong type parameters."
+            "\nExpected: KMutableMap<$T, $V>, Actual: ${destination.runtimeType}"
+            "\ndestination (${destination.runtimeType}) entries aren't subtype of "
+            "map ($runtimeType) entries. Entries can't be copied to destination."
+            "\n\n$kBug35518GenericTypeError");
       return true;
     }());
     for (var element in iter) {

--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -567,11 +567,18 @@ abstract class KIterableExtensionsMixin<T>
     return groups;
   }
 
-  M groupByTo<K, M extends KMutableMap<K, KMutableList<T>>>(
+  @override
+  M groupByTo<K, M extends KMutableMap<K, KMutableList<dynamic>>>(
       M destination, K Function(T) keySelector) {
     assert(() {
       if (destination == null) throw ArgumentError("destination can't be null");
       if (keySelector == null) throw ArgumentError("keySelector can't be null");
+      if (mutableMapOf<K, KMutableList<T>>() is! M)
+        throw ArgumentError("groupByTo destination has wrong type parameters."
+            "\nExpected: KMutableMap<K, KMutableList<$T>, Actual: ${destination.runtimeType}"
+            "\ndestination (${destination.runtimeType}) entries aren't subtype of "
+            "map ($runtimeType) entries. Entries can't be copied to destination."
+            "\n\n$kBug35518GenericTypeError");
       return true;
     }());
     for (final element in iter) {
@@ -1285,6 +1292,7 @@ abstract class KIterableExtensionsMixin<T>
     return list.toList();
   }
 
+  // TODO expose as C extends KMutableCollection<dynamic> https://github.com/dart-lang/sdk/issues/35518
   C toCollection<C extends KMutableCollection<T>>(C destination) {
     assert(() {
       if (destination == null) throw ArgumentError("destination can't be null");

--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -91,7 +91,6 @@ abstract class KIterableExtensionsMixin<T>
     return associateWithTo(linkedMapOf<T, V>(), valueSelector);
   }
 
-  // TODO add @override again
   M associateWithTo<V, M extends KMutableMap<T, V>>(
       M destination, V Function(T) valueSelector) {
     assert(() {
@@ -289,7 +288,6 @@ abstract class KIterableExtensionsMixin<T>
     return list;
   }
 
-  // TODO add @override again
   C filterIndexedTo<C extends KMutableCollection<T>>(
       C destination, bool Function(int index, T) predicate) {
     assert(() {
@@ -332,7 +330,6 @@ abstract class KIterableExtensionsMixin<T>
     return list;
   }
 
-  // TODO add @override again
   C filterNotNullTo<C extends KMutableCollection<T>>(C destination) {
     for (final element in iter) {
       if (element != null) {
@@ -342,7 +339,6 @@ abstract class KIterableExtensionsMixin<T>
     return destination;
   }
 
-  // TODO add @override again
   C filterNotTo<C extends KMutableCollection<T>>(
       C destination, bool Function(T) predicate) {
     assert(() {
@@ -358,7 +354,6 @@ abstract class KIterableExtensionsMixin<T>
     return destination;
   }
 
-  // TODO add @override again
   C filterTo<C extends KMutableCollection<T>>(
       C destination, bool Function(T) predicate) {
     assert(() {
@@ -522,7 +517,6 @@ abstract class KIterableExtensionsMixin<T>
     return groups;
   }
 
-  // TODO add @override again
   M groupByTo<K, M extends KMutableMap<K, KMutableList<T>>>(
       M destination, K Function(T) keySelector) {
     assert(() {

--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -90,6 +90,8 @@ abstract class KIterableExtensionsMixin<T>
   @override
   KMap<T, V> associateWith<V>(V Function(T) valueSelector) {
     final associated = associateWithTo(linkedMapOf<T, V>(), valueSelector);
+    // TODO ping dort-lang/sdk team to check type bug
+    // When in single line: type 'DartMutableList<String>' is not a subtype of type 'Null'
     return associated;
   }
 
@@ -352,7 +354,19 @@ abstract class KIterableExtensionsMixin<T>
     return list;
   }
 
-  C filterNotNullTo<C extends KMutableCollection<T>>(C destination) {
+  @override
+  C filterNotNullTo<C extends KMutableCollection<dynamic>>(C destination) {
+    assert(() {
+      if (destination == null) throw ArgumentError("destination can't be null");
+      if (mutableListOf<T>() is! C)
+        throw ArgumentError(
+            "filterNotNullTo destination has wrong type parameters."
+            "\nExpected: KMutableCollection<$T>, Actual: ${destination.runtimeType}"
+            "\ndestination (${destination.runtimeType}) entries aren't subtype of "
+            "map ($runtimeType) entries. Entries can't be copied to destination."
+            "\n\n$kBug35518GenericTypeError");
+      return true;
+    }());
     for (final element in iter) {
       if (element != null) {
         destination.add(element);

--- a/lib/src/extension/map_extensions_mixin.dart
+++ b/lib/src/extension/map_extensions_mixin.dart
@@ -16,13 +16,13 @@ abstract class KMapExtensionsMixin<K, V>
       M destination, bool Function(KMapEntry<K, V> entry) predicate) {
     assert(() {
       if (destination == null) throw ArgumentError("destination can't be null");
+      if (predicate == null) throw ArgumentError("predicate can't be null");
       if (mutableMapOf<K, V>() is! M)
         throw ArgumentError("filterTo destination has wrong type parameters."
             "\nExpected: KMutableMap<$K, $V>, Actual: ${destination.runtimeType}"
             "\ndestination (${destination.runtimeType}) entries aren't subtype of "
             "map ($runtimeType) entries. Entries can't be copied to destination."
             "\n\n$kBug35518GenericTypeError");
-      if (predicate == null) throw ArgumentError("predicate can't be null");
       return true;
     }());
     for (final element in entries.iter) {
@@ -45,13 +45,13 @@ abstract class KMapExtensionsMixin<K, V>
       M destination, bool Function(KMapEntry<K, V> entry) predicate) {
     assert(() {
       if (destination == null) throw ArgumentError("destination can't be null");
+      if (predicate == null) throw ArgumentError("predicate can't be null");
       if (mutableMapOf<K, V>() is! M)
         throw ArgumentError("filterNotTo destination has wrong type parameters."
             "\nExpected: KMutableMap<$K, $V>, Actual: ${destination.runtimeType}"
             "\ndestination (${destination.runtimeType}) entries aren't subtype of "
             "map ($runtimeType) entries. Entries can't be copied to destination."
             "\n\n$kBug35518GenericTypeError");
-      if (predicate == null) throw ArgumentError("predicate can't be null");
       return true;
     }());
     for (final element in entries.iter) {

--- a/lib/src/extension/map_extensions_mixin.dart
+++ b/lib/src/extension/map_extensions_mixin.dart
@@ -1,5 +1,6 @@
 import 'package:dart_kollection/dart_kollection.dart';
 import 'package:dart_kollection/src/k_map_mutable.dart';
+import 'package:dart_kollection/src/util/errors.dart';
 
 abstract class KMapExtensionsMixin<K, V>
     implements KMapExtension<K, V>, KMap<K, V> {
@@ -10,11 +11,17 @@ abstract class KMapExtensionsMixin<K, V>
     return filtered;
   }
 
-  // TODO add @override again
-  M filterTo<M extends KMutableMap<K, V>>(
+  @override
+  M filterTo<M extends KMutableMap<dynamic, dynamic>>(
       M destination, bool Function(KMapEntry<K, V> entry) predicate) {
     assert(() {
       if (destination == null) throw ArgumentError("destination can't be null");
+      if (mutableMapOf<K, V>() is! M)
+        throw ArgumentError("filterTo destination has wrong type parameters."
+            "\nExpected: KMutableMap<${K}, ${V}>, Actual: ${destination.runtimeType}"
+            "\ndestination (${destination.runtimeType}) entries aren't subtype of "
+            "map (${this.runtimeType}) entries. Entries can't be copied to destination."
+            "\n\n$kGenericTypeError");
       if (predicate == null) throw ArgumentError("predicate can't be null");
       return true;
     }());
@@ -33,11 +40,17 @@ abstract class KMapExtensionsMixin<K, V>
     return filtered;
   }
 
-  // TODO add @override again
-  M filterNotTo<M extends KMutableMap<K, V>>(
+  @override
+  M filterNotTo<M extends KMutableMap<dynamic, dynamic>>(
       M destination, bool Function(KMapEntry<K, V> entry) predicate) {
     assert(() {
       if (destination == null) throw ArgumentError("destination can't be null");
+      if (mutableMapOf<K, V>() is! M)
+        throw ArgumentError("filterNotTo destination has wrong type parameters."
+            "\nExpected: KMutableMap<${K}, ${V}>, Actual: ${destination.runtimeType}"
+            "\ndestination (${destination.runtimeType}) entries aren't subtype of "
+            "map (${this.runtimeType}) entries. Entries can't be copied to destination."
+            "\n\n$kGenericTypeError");
       if (predicate == null) throw ArgumentError("predicate can't be null");
       return true;
     }());

--- a/lib/src/extension/map_extensions_mixin.dart
+++ b/lib/src/extension/map_extensions_mixin.dart
@@ -98,15 +98,14 @@ abstract class KMapExtensionsMixin<K, V>
       M destination, R Function(KMapEntry<K, V> entry) transform) {
     assert(() {
       if (destination == null) throw ArgumentError("destination can't be null");
-
+      if (transform == null) throw ArgumentError("transform can't be null");
       final testType = mutableMapOf<R, V>();
       if (testType is! M)
         throw ArgumentError("mapKeysTo destination has wrong type parameters."
-            "\nExpected: ${testType.runtimeType}, Actual: ${destination.runtimeType}"
+            "\nExpected: KMutableMap<$R, $V>, Actual: ${destination.runtimeType}"
             "\nEntries after key transformation with $transform have type KMapEntry<$R, $V> "
             "and can't be copied into destination of type ${destination.runtimeType}."
             "\n\n$kBug35518GenericTypeError");
-      if (transform == null) throw ArgumentError("transform can't be null");
       return true;
     }());
     for (var element in entries.iter) {

--- a/lib/src/extension/map_extensions_mixin.dart
+++ b/lib/src/extension/map_extensions_mixin.dart
@@ -99,8 +99,7 @@ abstract class KMapExtensionsMixin<K, V>
     assert(() {
       if (destination == null) throw ArgumentError("destination can't be null");
       if (transform == null) throw ArgumentError("transform can't be null");
-      final testType = mutableMapOf<R, V>();
-      if (testType is! M)
+      if (mutableMapOf<R, V>() is! M)
         throw ArgumentError("mapKeysTo destination has wrong type parameters."
             "\nExpected: KMutableMap<$R, $V>, Actual: ${destination.runtimeType}"
             "\nEntries after key transformation with $transform have type KMapEntry<$R, $V> "
@@ -126,8 +125,7 @@ abstract class KMapExtensionsMixin<K, V>
     assert(() {
       if (destination == null) throw ArgumentError("destination can't be null");
       if (transform == null) throw ArgumentError("transform can't be null");
-      final testType = mutableMapOf<K, R>();
-      if (testType is! M)
+      if (mutableMapOf<K, R>() is! M)
         throw ArgumentError("mapValuesTo destination has wrong type parameters."
             "\nExpected: KMutableMap<$K, $R>, Actual: ${destination.runtimeType}"
             "\nEntries after key transformation with $transform have type KMapEntry<$K, $R> "

--- a/lib/src/extension/map_extensions_mixin.dart
+++ b/lib/src/extension/map_extensions_mixin.dart
@@ -120,9 +120,25 @@ abstract class KMapExtensionsMixin<K, V>
     return mapped;
   }
 
-  M mapValuesTo<R, M extends KMutableMap<K, R>>(
+  @override
+  M mapValuesTo<R, M extends KMutableMap<dynamic, dynamic>>(
       M destination, R Function(KMapEntry<K, V> entry) transform) {
-    return entries.associateByTo(destination, (it) => it.key, transform);
+    assert(() {
+      if (destination == null) throw ArgumentError("destination can't be null");
+      if (transform == null) throw ArgumentError("transform can't be null");
+      final testType = mutableMapOf<K, R>();
+      if (testType is! M)
+        throw ArgumentError("mapValuesTo destination has wrong type parameters."
+            "\nExpected: KMutableMap<$K, $R>, Actual: ${destination.runtimeType}"
+            "\nEntries after key transformation with $transform have type KMapEntry<$K, $R> "
+            "and can't be copied into destination of type ${destination.runtimeType}."
+            "\n\n$kBug35518GenericTypeError");
+      return true;
+    }());
+    for (var element in entries.iter) {
+      destination.put(element.key, transform(element));
+    }
+    return destination;
   }
 
   @override

--- a/lib/src/k_collection_mutable.dart
+++ b/lib/src/k_collection_mutable.dart
@@ -6,7 +6,10 @@ import 'package:dart_kollection/dart_kollection.dart';
  * @param E the type of elements contained in the collection. The mutable collection is invariant on its element type.
  */
 abstract class KMutableCollection<T>
-    implements KCollection<T>, KMutableIterable<T> {
+    implements
+        KCollection<T>,
+        KMutableIterable<T>,
+        KMutableCollectionExtension<T> {
   // Query Operations
   @override
   KMutableIterator<T> iterator();
@@ -55,3 +58,5 @@ abstract class KMutableCollection<T>
    */
   void clear();
 }
+
+abstract class KMutableCollectionExtension<T> {}

--- a/lib/src/k_iterable.dart
+++ b/lib/src/k_iterable.dart
@@ -102,9 +102,8 @@ abstract class KIterableExtension<T> {
    *
    * If any two elements are equal, the last one overwrites the former value in the map.
    */
-  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
-  // M associateWithTo<V, M extends KMutableMap<T, V>>(
-  //     M destination, V Function(T) valueSelector);
+  M associateWithTo<V, M extends KMutableMap<dynamic, dynamic>>(
+      M destination, V Function(T) valueSelector);
 
   /**
    * Returns an average value produced by [selector] function applied to each element in the collection.

--- a/lib/src/k_iterable.dart
+++ b/lib/src/k_iterable.dart
@@ -247,10 +247,14 @@ abstract class KIterableExtension<T> {
 
   /**
    * Appends all elements matching the given [predicate] to the given [destination].
+   *
+   * [destination] is not type checked by the compiler due to https://github.com/dart-lang/sdk/issues/35518,
+   * but will be checked at runtime.
+   * [C] actually is expected to be `C extends KMutableCollection<T>`
    */
-  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
-  // C filterTo<C extends KMutableCollection<T>>(
-  //     C destination, bool Function(T) predicate);
+  // TODO Change to `C extends KMutableCollection<T>` once https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  C filterTo<C extends KMutableCollection<dynamic>>(
+      C destination, bool Function(T) predicate);
 
   /**
    * Returns the first element matching the given [predicate], or `null` if no such element was found.

--- a/lib/src/k_iterable.dart
+++ b/lib/src/k_iterable.dart
@@ -208,10 +208,14 @@ abstract class KIterableExtension<T> {
    * Appends all elements matching the given [predicate] to the given [destination].
    * @param [predicate] function that takes the index of an element and the element itself
    * and returns the result of predicate evaluation on the element.
+   *
+   * [destination] is not type checked by the compiler due to https://github.com/dart-lang/sdk/issues/35518,
+   * but will be checked at runtime.
+   * [C] actually is expected to be `C extends KMutableCollection<T>`
    */
-  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
-  // C filterIndexedTo<C extends KMutableCollection<T>>(
-  //     C destination, bool Function(int index, T) predicate);
+  // TODO Change to `C extends KMutableCollection<T>` once https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  C filterIndexedTo<C extends KMutableCollection<dynamic>>(
+      C destination, bool Function(int index, T) predicate);
 
   /**
    * Returns a list containing all elements that are instances of specified type parameter R.

--- a/lib/src/k_iterable.dart
+++ b/lib/src/k_iterable.dart
@@ -101,7 +101,12 @@ abstract class KIterableExtension<T> {
    * where key is the element itself and value is provided by the [valueSelector] function applied to that key.
    *
    * If any two elements are equal, the last one overwrites the former value in the map.
+   *
+   * [destination] is not type checked by the compiler due to https://github.com/dart-lang/sdk/issues/35518,
+   * but will be checked at runtime.
+   * [M] actually is expected to be `M extends KMutableMap<T, V>`
    */
+  // TODO Change to `M extends KMutableMap<T, V>` once https://github.com/dart-lang/sdk/issues/35518 has been fixed
   M associateWithTo<V, M extends KMutableMap<dynamic, dynamic>>(
       M destination, V Function(T) valueSelector);
 

--- a/lib/src/k_iterable.dart
+++ b/lib/src/k_iterable.dart
@@ -234,9 +234,13 @@ abstract class KIterableExtension<T> {
 
   /**
    * Appends all elements that are not `null` to the given [destination].
+   *
+   * [destination] is not type checked by the compiler due to https://github.com/dart-lang/sdk/issues/35518,
+   * but will be checked at runtime.
+   * [C] actually is expected to be `C extends KMutableCollection<T>`
    */
-  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
-  // C filterNotNullTo<C extends KMutableCollection<T>>(C destination);
+  // TODO Change to `C extends KMutableCollection<T>` once https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  C filterNotNullTo<C extends KMutableCollection<dynamic>>(C destination);
 
   /**
    * Appends all elements not matching the given [predicate] to the given [destination].

--- a/lib/src/k_iterable.dart
+++ b/lib/src/k_iterable.dart
@@ -350,11 +350,13 @@ abstract class KIterableExtension<T> {
    * Groups elements of the original collection by the key returned by the given [keySelector] function
    * applied to each element and puts to the [destination] map each group key associated with a list of corresponding elements.
    *
-   * @return The [destination] map.
+   * [destination] is not type checked by the compiler due to https://github.com/dart-lang/sdk/issues/35518,
+   * but will be checked at runtime.
+   * [C] actually is expected to be `C extends KMutableCollection<T>`
    */
-  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
-  // M groupByTo<K, M extends KMutableMap<K, KMutableList<T>>>(
-  //     M destination, K Function(T) keySelector);
+  // TODO Change to `M extends KMutableMap<K, KMutableList<T>` once https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  M groupByTo<K, M extends KMutableMap<K, KMutableList<dynamic>>>(
+      M destination, K Function(T) keySelector);
 
   /**
    * Groups values returned by the [valueTransform] function applied to each element of the original collection

--- a/lib/src/k_iterable.dart
+++ b/lib/src/k_iterable.dart
@@ -240,10 +240,14 @@ abstract class KIterableExtension<T> {
 
   /**
    * Appends all elements not matching the given [predicate] to the given [destination].
+   *
+   * [destination] is not type checked by the compiler due to https://github.com/dart-lang/sdk/issues/35518,
+   * but will be checked at runtime.
+   * [C] actually is expected to be `C extends KMutableCollection<T>`
    */
-  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
-  // C filterNotTo<C extends KMutableCollection<T>>(
-  //     C destination, bool Function(T) predicate);
+  // TODO Change to `C extends KMutableCollection<T>` once https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  C filterNotTo<C extends KMutableCollection<dynamic>>(
+      C destination, bool Function(T) predicate);
 
   /**
    * Appends all elements matching the given [predicate] to the given [destination].

--- a/lib/src/k_map.dart
+++ b/lib/src/k_map.dart
@@ -103,11 +103,15 @@ abstract class KMapExtension<K, V> {
   /**
    * Appends all entries matching the given [predicate] into the mutable map given as [destination] parameter.
    *
+   * [destination] is not type checked by the compiler due to https://github.com/dart-lang/sdk/issues/35518,
+   * but will be checked at runtime.
+   * [M] actually is expected to be `M extends KMutableMap<K, V>`
+   *
    * @return the destination map.
    */
-  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
-  // M filterTo<M extends KMutableMap<K, V>>(
-  //     M destination, bool Function(KMapEntry<K, V> entry) predicate);
+  // TODO Change to `M extends KMutableMap<K, V>` once  has been fixed
+  M filterTo<M extends KMutableMap<dynamic, dynamic>>(
+      M destination, bool Function(KMapEntry<K, V> entry) predicate);
 
   /**
    * Returns a new map containing all key-value pairs not matching the given [predicate].
@@ -119,11 +123,15 @@ abstract class KMapExtension<K, V> {
   /**
    * Appends all entries not matching the given [predicate] into the given [destination].
    *
+   * [destination] is not type checked by the compiler due to https://github.com/dart-lang/sdk/issues/35518,
+   * but will be checked at runtime.
+   * [M] actually is expected to be `M extends KMutableMap<K, V>`
+   *
    * @return the destination map.
    */
-  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
-  // M filterNotTo<M extends KMutableMap<K, V>>(
-  //     M destination, bool Function(KMapEntry<K, V> entry) predicate);
+  // TODO Change to `M extends KMutableMap<K, V>` once https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  M filterNotTo<M extends KMutableMap<dynamic, dynamic>>(
+      M destination, bool Function(KMapEntry<K, V> entry) predicate);
 
   /**
    * Returns the value for the given key, or the result of the [defaultValue] function if there was no entry for the given key.

--- a/lib/src/k_map.dart
+++ b/lib/src/k_map.dart
@@ -109,7 +109,7 @@ abstract class KMapExtension<K, V> {
    *
    * @return the destination map.
    */
-  // TODO Change to `M extends KMutableMap<K, V>` once  has been fixed
+  // TODO Change to `M extends KMutableMap<K, V>` once https://github.com/dart-lang/sdk/issues/35518 has been fixed
   M filterTo<M extends KMutableMap<dynamic, dynamic>>(
       M destination, bool Function(KMapEntry<K, V> entry) predicate);
 

--- a/lib/src/k_map.dart
+++ b/lib/src/k_map.dart
@@ -178,6 +178,7 @@ abstract class KMapExtension<K, V> {
    * but will be checked at runtime.
    * [M] actually is expected to be `M extends KMutableMap<R, V>`
    */
+  // TODO Change to `M extends KMutableMap<R, V>` once https://github.com/dart-lang/sdk/issues/35518 has been fixed
   M mapKeysTo<R, M extends KMutableMap<dynamic, dynamic>>(
       M destination, R Function(KMapEntry<K, V> entry) transform);
 
@@ -192,10 +193,14 @@ abstract class KMapExtension<K, V> {
   /**
    * Populates the given [destination] map with entries having the keys of this map and the values obtained
    * by applying the [transform] function to each entry in this [Map].
+   *
+   * [destination] is not type checked by the compiler due to https://github.com/dart-lang/sdk/issues/35518,
+   * but will be checked at runtime.
+   * [M] actually is expected to be `M extends KMutableMap<K, R>`
    */
-  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
-  // M mapValuesTo<R, M extends KMutableMap<K, R>>(
-  //     M destination, R Function(KMapEntry<K, V> entry) transform);
+  // TODO Change to `M extends KMutableMap<K, R>` once https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  M mapValuesTo<R, M extends KMutableMap<dynamic, dynamic>>(
+      M destination, R Function(KMapEntry<K, V> entry) transform);
 
   /**
    * Returns a map containing all entries of the original map except the entry with the given [key].

--- a/lib/src/k_map.dart
+++ b/lib/src/k_map.dart
@@ -173,10 +173,13 @@ abstract class KMapExtension<K, V> {
    *
    * In case if any two entries are mapped to the equal keys, the value of the latter one will overwrite
    * the value associated with the former one.
+   *
+   * [destination] is not type checked by the compiler due to https://github.com/dart-lang/sdk/issues/35518,
+   * but will be checked at runtime.
+   * [M] actually is expected to be `M extends KMutableMap<R, V>`
    */
-  // TODO add after https://github.com/dart-lang/sdk/issues/35518 has been fixed
-  // M mapKeysTo<R, M extends KMutableMap<R, V>>(
-  //     M destination, R Function(KMapEntry<K, V> entry) transform);
+  M mapKeysTo<R, M extends KMutableMap<dynamic, dynamic>>(
+      M destination, R Function(KMapEntry<K, V> entry) transform);
 
   /**
    * Returns a new map with entries having the keys of this map and the values obtained by applying the [transform]

--- a/lib/src/util/errors.dart
+++ b/lib/src/util/errors.dart
@@ -1,4 +1,4 @@
-const kGenericTypeError = """
+const String kBug35518GenericTypeError = """
 This type error can't be caught at compile time due to a bug in the dart compiler.
 Please upvote https://github.com/dart-lang/sdk/issues/35518 if you want this error to be cought earlier.
 """;

--- a/lib/src/util/errors.dart
+++ b/lib/src/util/errors.dart
@@ -1,0 +1,4 @@
+const kGenericTypeError = """
+This type error can't be caught at compile time due to a bug in the dart compiler.
+Please upvote https://github.com/dart-lang/sdk/issues/35518 if you want this error to be cought earlier.
+""";

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -528,6 +528,59 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
     });
   });
 
+  group("filterTo", () {
+    test("filterTo same type", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<int>();
+      final filtered = iterable.filterTo(result, (it) => it < 10);
+      expect(identical(result, filtered), isTrue);
+      if (ordered) {
+        expect(result, listOf([4, -12]));
+      } else {
+        expect(result.toSet(), setOf([4, -12]));
+      }
+    });
+    test("filterTo super type", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<num>();
+      final filtered = iterable.filterTo(result, (it) => it < 10);
+      expect(identical(result, filtered), isTrue);
+      if (ordered) {
+        expect(result, listOf([4, -12]));
+      } else {
+        expect(result.toSet(), equals(setOf([4, -12])));
+      }
+    });
+    test("filterTo wrong type throws", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<String>();
+      final e = catchException<ArgumentError>(
+          () => iterable.filterTo(result, (it) => it < 10));
+      expect(
+          e.message,
+          allOf(
+            contains("filterTo"),
+            contains("destination"),
+            contains("<int>"),
+            contains("<String>"),
+          ));
+    });
+    test("filterTo requires predicate to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final bool Function(String) predicate = null;
+      final other = mutableListOf<String>();
+      final e = catchException<ArgumentError>(
+          () => iterable.filterTo(other, predicate));
+      expect(e.message, allOf(contains("null"), contains("predicate")));
+    });
+    test("filterTo requires destination to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final e = catchException<ArgumentError>(
+          () => iterable.filterTo(null, (it) => true));
+      expect(e.message, allOf(contains("null"), contains("destination")));
+    });
+  });
+
   group("filterIndexed", () {
     test("filterIndexed", () {
       final iterable = iterableOf(["paul", "peter", "john", "lisa"]);

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -740,6 +740,51 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
     });
   });
 
+  group("filterNotNullTo", () {
+    test("filterNotNullTo same type", () {
+      final iterable = iterableOf([4, 25, null, 10]);
+      final result = mutableListOf<int>();
+      final filtered = iterable.filterNotNullTo(result);
+      expect(identical(result, filtered), isTrue);
+      if (ordered) {
+        expect(result, listOf([4, 25, 10]));
+      } else {
+        expect(result.toSet(), setOf([4, 25, 10]));
+      }
+    });
+    test("filterNotNullTo super type", () {
+      final iterable = iterableOf([4, 25, null, 10]);
+      final result = mutableListOf<num>();
+      final filtered = iterable.filterNotNullTo(result);
+      expect(identical(result, filtered), isTrue);
+      if (ordered) {
+        expect(result, listOf([4, 25, 10]));
+      } else {
+        expect(result.toSet(), equals(setOf([4, 25, 10])));
+      }
+    });
+    test("filterNotNullTo wrong type throws", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<String>();
+      final e =
+          catchException<ArgumentError>(() => iterable.filterNotNullTo(result));
+      expect(
+          e.message,
+          allOf(
+            contains("filterNotNullTo"),
+            contains("destination"),
+            contains("<int>"),
+            contains("<String>"),
+          ));
+    });
+    test("filterNotNullTo requires destination to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final e =
+          catchException<ArgumentError>(() => iterable.filterNotNullTo(null));
+      expect(e.message, allOf(contains("null"), contains("destination")));
+    });
+  });
+
   group("filterIsInstance", () {
     test("filterIsInstance", () {
       final iterable = iterableOf<Object>(["paul", null, "john", 1, "lisa"]);

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -679,6 +679,59 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
     });
   });
 
+  group("filterNotTo", () {
+    test("filterNotTo same type", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<int>();
+      final filtered = iterable.filterNotTo(result, (it) => it < 10);
+      expect(identical(result, filtered), isTrue);
+      if (ordered) {
+        expect(result, listOf([25, 10]));
+      } else {
+        expect(result.toSet(), setOf([25, 10]));
+      }
+    });
+    test("filterNotTo super type", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<num>();
+      final filtered = iterable.filterNotTo(result, (it) => it < 10);
+      expect(identical(result, filtered), isTrue);
+      if (ordered) {
+        expect(result, listOf([25, 10]));
+      } else {
+        expect(result.toSet(), equals(setOf([25, 10])));
+      }
+    });
+    test("filterNotTo wrong type throws", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<String>();
+      final e = catchException<ArgumentError>(
+          () => iterable.filterNotTo(result, (it) => it < 10));
+      expect(
+          e.message,
+          allOf(
+            contains("filterNotTo"),
+            contains("destination"),
+            contains("<int>"),
+            contains("<String>"),
+          ));
+    });
+    test("filterNotTo requires predicate to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final bool Function(String) predicate = null;
+      final other = mutableListOf<String>();
+      final e = catchException<ArgumentError>(
+          () => iterable.filterNotTo(other, predicate));
+      expect(e.message, allOf(contains("null"), contains("predicate")));
+    });
+    test("filterNotTo requires destination to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final e = catchException<ArgumentError>(
+          () => iterable.filterNotTo(null, (it) => true));
+      expect(e.message, allOf(contains("null"), contains("destination")));
+    });
+  });
+
   group("filterNotNull", () {
     test("filterNotNull", () {
       final iterable = iterableOf(["paul", null, "john", "lisa"]);

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -156,19 +156,64 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
   group('associateWith', () {
     test("associateWith", () {
       final iterable = iterableOf(["a", "b", "c"]);
-      var result = iterable.associateWith((it) => it.toUpperCase());
+      var result = iterable.associateWith((it) => it.length);
       var expected = mapOf({"a": "A", "b": "B", "c": "C"});
       expect(result, equals(expected));
     });
     test("associateWith on empty map", () {
       final iterable = emptyIterable<String>();
-      var result = iterable.associateWith((it) => it.toUpperCase());
+      var result = iterable.associateWith((it) => it.length);
       expect(result, equals(emptyMap()));
     });
     test("associateWith doesn't allow null as valueSelector", () {
       final list = emptyIterable<String>();
       var e = catchException<ArgumentError>(() => list.associateWith(null));
       expect(e.message, allOf(contains("null"), contains("valueSelector")));
+    });
+  });
+
+  group("associateWithTo", () {
+    test("associateWithTo same type", () {
+      final iterable = iterableOf(["a", "bb", "ccc"]);
+      final result = mutableMapOf<String, int>();
+      final filtered = iterable.associateWithTo(result, (it) => it.length);
+      expect(identical(result, filtered), isTrue);
+      expect(result, mapOf({"a": 1, "bb": 2, "ccc": 3}));
+    });
+    test("associateWithTo super type", () {
+      final iterable = iterableOf(["a", "bb", "ccc"]);
+      final result = mutableMapOf<String, num>();
+      final filtered = iterable.associateWithTo(result, (it) => it.length);
+      expect(identical(result, filtered), isTrue);
+      expect(result, mapOf({"a": 1, "bb": 2, "ccc": 3}));
+    });
+    test("associateWithTo wrong type throws", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final result = mutableMapOf<String, String>();
+      final e = catchException<ArgumentError>(
+          () => iterable.associateWithTo(result, (entry) => entry.length));
+      expect(
+          e.message,
+          allOf(
+            contains("associateWithTo"),
+            contains("destination"),
+            contains("<String, String>"),
+            contains("<String, int>"),
+          ));
+    });
+    test("associateWithTo requires valueSelector to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final String Function(String item) predicate = null;
+      final other = mutableMapOf<String, String>();
+      final e = catchException<ArgumentError>(
+          () => iterable.associateWithTo(other, predicate));
+      expect(e.message, allOf(contains("null"), contains("valueSelector")));
+    });
+    test("associateWithTo requires destination to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final e = catchException<ArgumentError>(
+          () => iterable.associateWithTo(null, (it) => it.toUpperCase()));
+      expect(e.message, allOf(contains("null"), contains("destination")));
     });
   });
 

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -601,6 +601,70 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
     });
   });
 
+  group("filterIndexedTo", () {
+    test("filterIndexedTo index is incrementing", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<int>();
+      var index = 0;
+      iterable.filterIndexedTo(result, (i, it) {
+        expect(i, index);
+        index++;
+        return true;
+      });
+      expect(index, 4);
+    });
+    test("filterIndexedTo same type", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<int>();
+      final filtered = iterable.filterIndexedTo(result, (i, it) => it < 10);
+      expect(identical(result, filtered), isTrue);
+      if (ordered) {
+        expect(result, listOf([4, -12]));
+      } else {
+        expect(result.toSet(), setOf([4, -12]));
+      }
+    });
+    test("filterIndexedTo super type", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<num>();
+      final filtered = iterable.filterIndexedTo(result, (i, it) => it < 10);
+      expect(identical(result, filtered), isTrue);
+      if (ordered) {
+        expect(result, listOf([4, -12]));
+      } else {
+        expect(result.toSet(), equals(setOf([4, -12])));
+      }
+    });
+    test("filterIndexedTo wrong type throws", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<String>();
+      final e = catchException<ArgumentError>(
+          () => iterable.filterIndexedTo(result, (i, it) => it < 10));
+      expect(
+          e.message,
+          allOf(
+            contains("filterIndexedTo"),
+            contains("destination"),
+            contains("<int>"),
+            contains("<String>"),
+          ));
+    });
+    test("filterIndexedTo requires predicate to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final bool Function(int, String) predicate = null;
+      final other = mutableListOf<String>();
+      final e = catchException<ArgumentError>(
+          () => iterable.filterIndexedTo(other, predicate));
+      expect(e.message, allOf(contains("null"), contains("predicate")));
+    });
+    test("filterIndexedTo requires destination to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final e = catchException<ArgumentError>(
+          () => iterable.filterIndexedTo(null, (i, it) => true));
+      expect(e.message, allOf(contains("null"), contains("destination")));
+    });
+  });
+
   group("filterNot", () {
     test("filterNot", () {
       final iterable = iterableOf(["paul", "peter", "john", "lisa"]);

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -156,18 +156,18 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
   group('associateWith', () {
     test("associateWith", () {
       final iterable = iterableOf(["a", "b", "c"]);
-      var result = iterable.associateWith((it) => it.length);
-      var expected = mapOf({"a": "A", "b": "B", "c": "C"});
+      final result = iterable.associateWith((it) => it.toUpperCase());
+      final expected = mapOf({"a": "A", "b": "B", "c": "C"});
       expect(result, equals(expected));
     });
     test("associateWith on empty map", () {
       final iterable = emptyIterable<String>();
-      var result = iterable.associateWith((it) => it.length);
+      final result = iterable.associateWith((it) => it.toUpperCase());
       expect(result, equals(emptyMap()));
     });
     test("associateWith doesn't allow null as valueSelector", () {
       final list = emptyIterable<String>();
-      var e = catchException<ArgumentError>(() => list.associateWith(null));
+      final e = catchException<ArgumentError>(() => list.associateWith(null));
       expect(e.message, allOf(contains("null"), contains("valueSelector")));
     });
   });

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -1041,7 +1041,64 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
       var e = catchException<ArgumentError>(() => iterable.groupBy(null));
       expect(e.message, allOf(contains("null"), contains("keySelector")));
     });
+  });
 
+  group("groupByTo", () {
+    test("groupByTo same type", () {
+      final iterable = iterableOf(["paul", "peter", "john", "lisa"]);
+      final result = mutableMapOf<int, KMutableList<String>>();
+      final grouped = iterable.groupByTo(result, (it) => it.length);
+      expect(identical(result, grouped), isTrue);
+      expect(
+          result,
+          mapOf({
+            4: iterableOf(["paul", "john", "lisa"]).toList(),
+            5: listOf(["peter"]),
+          }));
+    });
+    test("groupByTo super type", () {
+      final iterable = iterableOf(["paul", "peter", "john", "lisa"]);
+      final result = mutableMapOf<int, KMutableList<Pattern>>();
+      final grouped = iterable.groupByTo(result, (it) => it.length);
+      expect(identical(result, grouped), isTrue);
+      expect(
+          result,
+          mapOf({
+            4: iterableOf(["paul", "john", "lisa"]).toList(),
+            5: listOf(["peter"]),
+          }));
+    });
+    test("groupByTo wrong type throws", () {
+      final iterable = iterableOf(["paul", "peter", "john", "lisa"]);
+      final result = mutableMapOf<int, KMutableList<int>>();
+      final e = catchException<ArgumentError>(
+          () => iterable.groupByTo(result, (it) => it.length));
+      expect(
+          e.message,
+          allOf(
+            contains("groupByTo"),
+            contains("destination"),
+            contains("KMutableList<int>"),
+            contains("KMutableList<String>"),
+          ));
+    });
+    test("groupByTo requires destination to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final e = catchException<ArgumentError>(
+          () => iterable.groupByTo(null, (it) => it.length));
+      expect(e.message, allOf(contains("null"), contains("destination")));
+    });
+    test("groupByTo requires keySelector to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final String Function(String) keySelector = null;
+      final other = mutableMapOf<String, KMutableList<String>>();
+      final e = catchException<ArgumentError>(
+          () => iterable.groupByTo(other, keySelector));
+      expect(e.message, allOf(contains("null"), contains("keySelector")));
+    });
+  });
+
+  group("groupByTransform", () {
     test("groupByTransform doesn't allow null as keySelector", () {
       final iterable = iterableOf([1, 2, 3]);
       var e = catchException<ArgumentError>(

--- a/test/collection/list_mutable_test.dart
+++ b/test/collection/list_mutable_test.dart
@@ -198,5 +198,12 @@ void main() {
           () => mutableListOf(["a", "b", "c"]).listIterator(null));
       expect(e.message, allOf(contains("null"), contains("index")));
     });
+
+    test("equals although differnt types (subtypes)", () {
+      expect(mutableListOf<int>([1, 2, 3]), mutableListOf<num>([1, 2, 3]));
+      expect(mutableListOf<num>([1, 2, 3]), mutableListOf<int>([1, 2, 3]));
+      expect(linkedSetOf<int>([1, 2, 3]), linkedSetOf<num>([1, 2, 3]));
+      expect(linkedSetOf<num>([1, 2, 3]), linkedSetOf<int>([1, 2, 3]));
+    });
   });
 }

--- a/test/collection/list_test.dart
+++ b/test/collection/list_test.dart
@@ -206,5 +206,10 @@ void main() {
       expect(e.message, contains("index"));
       expect(e.message, contains("null"));
     });
+
+    test("equals although differnt types (subtypes)", () {
+      expect(listOf<int>([1, 2, 3]), listOf<num>([1, 2, 3]));
+      expect(listOf<num>([1, 2, 3]), listOf<int>([1, 2, 3]));
+    });
   });
 }

--- a/test/collection/map_extensions_test.dart
+++ b/test/collection/map_extensions_test.dart
@@ -32,6 +32,82 @@ void main() {
     });
   });
 
+  group("filterTo", () {
+    test("filterTo same type", () {
+      final result = mutableMapOf<int, String>();
+      final filtered =
+          pokemon.filterTo(result, (entry) => entry.value.startsWith("I"));
+      expect(identical(result, filtered), isTrue);
+      expect(result, mapOf({2: "Ivysaur"}));
+    });
+    test("filterTo super type", () {
+      final result = mutableMapOf<num, String>();
+      final filtered =
+          pokemon.filterTo(result, (entry) => entry.value.startsWith("I"));
+      expect(identical(result, filtered), isTrue);
+      expect(result, mapOf({2: "Ivysaur"}));
+    });
+    test("filterTo wrong type throws", () {
+      final result = mutableMapOf<String, String>();
+      final e = catchException<ArgumentError>(() =>
+          pokemon.filterTo(result, (entry) => entry.value.startsWith("I")));
+      expect(
+          e.message,
+          allOf(contains("filterTo"), contains("destination"),
+              contains("<String, String>"), contains("<int, String>")));
+    });
+    test("filterTo requires predicate to be non null", () {
+      bool Function(KMapEntry<int, String> entry) predicate = null;
+      var other = mutableMapOf<int, String>();
+      final e = catchException<ArgumentError>(
+          () => pokemon.filterTo(other, predicate));
+      expect(e.message, allOf(contains("null"), contains("predicate")));
+    });
+    test("filterTo requires destination to be non null", () {
+      final e = catchException<ArgumentError>(
+          () => pokemon.filterTo(null, (it) => true));
+      expect(e.message, allOf(contains("null"), contains("destination")));
+    });
+  });
+
+  group("filterNotTo", () {
+    test("filterNotTo same type", () {
+      final result = mutableMapOf<int, String>();
+      final filtered =
+          pokemon.filterNotTo(result, (entry) => entry.value.startsWith("I"));
+      expect(identical(result, filtered), isTrue);
+      expect(result, mapOf({1: "Bulbasaur"}));
+    });
+    test("filterNotTo super type", () {
+      final result = mutableMapOf<num, String>();
+      final filtered =
+          pokemon.filterNotTo(result, (entry) => entry.value.startsWith("I"));
+      expect(identical(result, filtered), isTrue);
+      expect(result, mapOf({1: "Bulbasaur"}));
+    });
+    test("filterNotTo wrong type throws", () {
+      final result = mutableMapOf<String, String>();
+      final e = catchException<ArgumentError>(() =>
+          pokemon.filterNotTo(result, (entry) => entry.value.startsWith("I")));
+      expect(
+          e.message,
+          allOf(contains("filterNotTo"), contains("destination"),
+              contains("<String, String>"), contains("<int, String>")));
+    });
+    test("filterNotTo requires predicate to be non null", () {
+      bool Function(KMapEntry<int, String> entry) predicate = null;
+      var other = mutableMapOf<int, String>();
+      final e = catchException<ArgumentError>(
+          () => pokemon.filterNotTo(other, predicate));
+      expect(e.message, allOf(contains("null"), contains("predicate")));
+    });
+    test("filterNotTo requires destination to be non null", () {
+      final e = catchException<ArgumentError>(
+          () => pokemon.filterNotTo(null, (it) => true));
+      expect(e.message, allOf(contains("null"), contains("destination")));
+    });
+  });
+
   group("get", () {
     test("get", () {
       expect(pokemon.get(1), "Bulbasaur");

--- a/test/collection/map_extensions_test.dart
+++ b/test/collection/map_extensions_test.dart
@@ -216,7 +216,7 @@ void main() {
     });
     test("mapKeysTo requires transform to be non null", () {
       bool Function(KMapEntry<int, String> entry) predicate = null;
-      var other = mutableMapOf<int, String>();
+      final other = mutableMapOf<int, String>();
       final e = catchException<ArgumentError>(
           () => pokemon.mapKeysTo(other, predicate));
       expect(e.message, allOf(contains("null"), contains("transform")));
@@ -228,12 +228,64 @@ void main() {
     });
   });
 
-  group("map values", () {
+  group("mapValues", () {
     test("map values", () {
       final mapped = pokemon.mapValues((entry) => entry.value.toUpperCase());
       expect(mapped[1], "BULBASAUR");
       expect(mapped[2], "IVYSAUR");
       expect(mapped.size, 2);
+    });
+  });
+
+  group("mapValuesTo", () {
+    test("mapValuesTo same type", () {
+      final result = mutableMapOf<int, String>();
+      final filtered = pokemon.mapValuesTo(
+          result, (entry) => "${entry.value}${entry.value.length}");
+      expect(identical(result, filtered), isTrue);
+      expect(
+          result,
+          mapOf({
+            1: "Bulbasaur9",
+            2: "Ivysaur7",
+          }));
+    });
+    test("mapValuesTo super type", () {
+      final result = mutableMapOf<num, String>();
+      final filtered = pokemon.mapValuesTo(
+          result, (entry) => "${entry.value}${entry.value.length}");
+      expect(identical(result, filtered), isTrue);
+      expect(
+          result,
+          mapOf({
+            1: "Bulbasaur9",
+            2: "Ivysaur7",
+          }));
+    });
+    test("mapValuesTo wrong type throws", () {
+      final result = mutableMapOf<int, int>();
+      final e = catchException<ArgumentError>(() => pokemon.mapValuesTo(
+          result, (entry) => "${entry.value}${entry.value.length}"));
+      expect(
+          e.message,
+          allOf(
+            contains("mapValuesTo"),
+            contains("destination"),
+            contains("<int, String>"),
+            contains("<int, int>"),
+          ));
+    });
+    test("mapValuesTo requires transform to be non null", () {
+      bool Function(KMapEntry<int, String> entry) predicate = null;
+      final other = mutableMapOf<int, String>();
+      final e = catchException<ArgumentError>(
+          () => pokemon.mapValuesTo(other, predicate));
+      expect(e.message, allOf(contains("null"), contains("transform")));
+    });
+    test("mapValuesTo requires destination to be non null", () {
+      final e = catchException<ArgumentError>(
+          () => pokemon.mapValuesTo(null, (it) => true));
+      expect(e.message, allOf(contains("null"), contains("destination")));
     });
   });
 

--- a/test/collection/map_extensions_test.dart
+++ b/test/collection/map_extensions_test.dart
@@ -178,6 +178,56 @@ void main() {
     });
   });
 
+  group("mapKeysTo", () {
+    test("mapKeysTo same type", () {
+      final result = mutableMapOf<int, String>();
+      final filtered = pokemon.mapKeysTo(result, (entry) => entry.key + 1000);
+      expect(identical(result, filtered), isTrue);
+      expect(
+          result,
+          mapOf({
+            1001: "Bulbasaur",
+            1002: "Ivysaur",
+          }));
+    });
+    test("mapKeysTo super type", () {
+      final result = mutableMapOf<num, String>();
+      final filtered = pokemon.mapKeysTo(result, (entry) => entry.key + 1000);
+      expect(identical(result, filtered), isTrue);
+      expect(
+          result,
+          mapOf({
+            1001: "Bulbasaur",
+            1002: "Ivysaur",
+          }));
+    });
+    test("mapKeysTo wrong type throws", () {
+      final result = mutableMapOf<String, String>();
+      final e = catchException<ArgumentError>(
+          () => pokemon.mapKeysTo(result, (entry) => entry.key + 1000));
+      expect(
+          e.message,
+          allOf(
+            contains("mapKeysTo"),
+            contains("destination"),
+            contains("<String, String>"),
+            contains("<int, String>"),
+          ));
+    });
+    test("mapKeysTo requires transform to be non null", () {
+      bool Function(KMapEntry<int, String> entry) predicate = null;
+      var other = mutableMapOf<int, String>();
+      final e = catchException<ArgumentError>(
+          () => pokemon.mapKeysTo(other, predicate));
+      expect(e.message, allOf(contains("null"), contains("transform")));
+    });
+    test("mapKeysTo requires destination to be non null", () {
+      final e = catchException<ArgumentError>(
+          () => pokemon.mapKeysTo(null, (it) => true));
+      expect(e.message, allOf(contains("null"), contains("destination")));
+    });
+  });
+
   group("map values", () {
     test("map values", () {
       final mapped = pokemon.mapValues((entry) => entry.value.toUpperCase());

--- a/test/collection/map_test.dart
+++ b/test/collection/map_test.dart
@@ -25,4 +25,17 @@ void main() {
       expect(map.toString(), "{}");
     });
   });
+
+  group("equals", () {
+    test("equals altough only subtypes", () {
+      expect(mapOf<int, String>({1: "a", 2: "b"}),
+          mapOf<num, String>({1: "a", 2: "b"}));
+      expect(mapOf<num, String>({1: "a", 2: "b"}),
+          mapOf<int, String>({1: "a", 2: "b"}));
+      expect(mapOf<String, int>({"a": 1, "b": 2}),
+          mapOf<String, num>({"a": 1, "b": 2}));
+      expect(mapOf<String, num>({"a": 1, "b": 2}),
+          mapOf<String, int>({"a": 1, "b": 2}));
+    });
+  });
 }

--- a/test/collection/set_test.dart
+++ b/test/collection/set_test.dart
@@ -87,5 +87,10 @@ void main() {
       expect(set.length, 3);
       expect(set, equals(Set.from(["a", "b", "c"])));
     });
+
+    test("equals although differnt types (subtypes)", () {
+      expect(setOf<int>([1, 2, 3]), setOf<num>([1, 2, 3]));
+      expect(setOf<num>([1, 2, 3]), setOf<int>([1, 2, 3]));
+    });
   });
 }


### PR DESCRIPTION
Followup to #46, adding all removed functions again.

The bug in dart https://github.com/dart-lang/sdk/issues/35518 still exists but it is possible to work around it. It's possible to check they incoming type at runtime. This doesn't make the API statically typed but I rather provide the methods with a runtime check to users than not providing the methods.

It will be non-breaking to change the API to be statically typed, once a bugfix landed.

#### Revived:
- [x] `KIterable<T>.associateWithTo`
- [x] `Kiterable<T>.filterTo`
- [x] `KIterable<T>.filterIndexedTo`
- [x] `KIterable<T>.filterNotTo`
- [x] `KIterable<T>.filterNotNullTo`
- [x] `KIterable<T>.groupByTo`
- [x] `KMap<T>.mapKeysTo`
- [x] `KMap<T>.mapValuesTo`

#### fix `KSet` equals 
Also I fixed the equals implementation of Set, which wasn't working properly when comparing `KSet<int>` to `KSet<num>`