### PR TITLE
KIterable.toCollection

### DIFF
--- a/lib/src/extension/iterable_extension_mixin.dart
+++ b/lib/src/extension/iterable_extension_mixin.dart
@@ -1292,10 +1292,17 @@ abstract class KIterableExtensionsMixin<T>
     return list.toList();
   }
 
-  // TODO expose as C extends KMutableCollection<dynamic> https://github.com/dart-lang/sdk/issues/35518
-  C toCollection<C extends KMutableCollection<T>>(C destination) {
+  @override
+  C toCollection<C extends KMutableCollection<dynamic>>(C destination) {
     assert(() {
       if (destination == null) throw ArgumentError("destination can't be null");
+      if (mutableListOf<T>() is! C)
+        throw ArgumentError(
+            "toCollection destination has wrong type parameters."
+            "\nExpected: KMutableCollection<$T>, Actual: ${destination.runtimeType}"
+            "\ndestination (${destination.runtimeType}) entries aren't subtype of "
+            "map ($runtimeType) entries. Entries can't be copied to destination."
+            "\n\n$kBug35518GenericTypeError");
       return true;
     }());
     for (final item in iter) {

--- a/lib/src/k_iterable.dart
+++ b/lib/src/k_iterable.dart
@@ -665,6 +665,16 @@ abstract class KIterableExtension<T> {
   KList<T> take(int n);
 
   /**
+   * Appends all elements to the given [destination] collection.
+   *
+   * [destination] is not type checked by the compiler due to https://github.com/dart-lang/sdk/issues/35518,
+   * but will be checked at runtime.
+   * [M] actually is expected to be `M extends KMutableCollection<T>`
+   */
+  // TODO Change to `M extends KMutableCollection<T>` once https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  C toCollection<C extends KMutableCollection<dynamic>>(C destination);
+
+  /**
    * Returns a HashSet of all elements.
    */
   KMutableSet<T> toHashSet();

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -625,11 +625,10 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
       }
     });
     test("filterIndexedTo super type", () {
-      final iterable = iterableOf([4, 25, -12, 10]);
+      final KIterable<int> iterable = listOf([4, 25, -12, 10]);
       final result = mutableListOf<num>();
       final filtered = iterable.filterIndexedTo(result, (i, it) => it < 10);
       expect(identical(result, filtered), isTrue);
-      if (ordered) {
         expect(result, listOf([4, -12]));
       } else {
         expect(result.toSet(), equals(setOf([4, -12])));
@@ -1944,6 +1943,54 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
       expect(e.message, allOf(contains("null"), contains("n")));
     });
   });
+
+
+  group("toCollection", () {
+    test("toCollection same type", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<int>();
+      final filtered = iterable.toCollection(result);
+      expect(identical(result, filtered), isTrue);
+      if (ordered) {
+        expect(result, listOf([4, -12]));
+      } else {
+        expect(result.toSet(), setOf([4, -12]));
+      }
+    });
+    test("toCollection super type", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<num>();
+      final filtered = iterable.toCollection(result);
+      expect(identical(result, filtered), isTrue);
+      if (ordered) {
+        expect(result, listOf([4, -12]));
+      } else {
+        expect(result.toSet(), equals(setOf([4, -12])));
+      }
+    });
+    test("toCollection wrong type throws", () {
+      final iterable = iterableOf([4, 25, -12, 10]);
+      final result = mutableListOf<String>();
+      final e = catchException<ArgumentError>(
+              () => iterable.toCollection(result));
+      expect(
+          e.message,
+          allOf(
+            contains("toCollection"),
+            contains("destination"),
+            contains("<int>"),
+            contains("<String>"),
+          ));
+    });
+    test("toCollection requires destination to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final e = catchException<ArgumentError>(
+              () => iterable.toCollection(null, (it) => true));
+      expect(e.message, allOf(contains("null"), contains("destination")));
+    });
+  });
+  
+  
   group("windowed", () {
     test("default step", () {
       expect(

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -1121,6 +1121,50 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
     });
   });
 
+  group("groupByToTransform", () {
+    test("groupByToTransform same type", () {
+      final iterable = iterableOf(["paul", "peter", "john", "lisa"]);
+      final result = mutableMapOf<int, KMutableList<String>>();
+      final grouped = iterable.groupByToTransform(
+          result, (it) => it.length, (it) => it.toUpperCase());
+      expect(identical(result, grouped), isTrue);
+      if (ordered) {
+        expect(
+            result,
+            mapOf({
+              4: listOf(["PAUL", "JOHN", "LISA"]),
+              5: listOf(["PETER"]),
+            }));
+      } else {
+        expect(result.size, 2);
+        expect(result[4].toSet(), setOf(["PAUL", "JOHN", "LISA"]));
+        expect(result[5], listOf(["PETER"]));
+      }
+    });
+    test("groupByToTransform requires destination to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final e = catchException<ArgumentError>(() => iterable.groupByToTransform(
+          null, (it) => it.length, (it) => it.toUpperCase()));
+      expect(e.message, allOf(contains("null"), contains("destination")));
+    });
+    test("groupByToTransform requires keySelector to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final String Function(String) keySelector = null;
+      final other = mutableMapOf<String, KMutableList<String>>();
+      final e = catchException<ArgumentError>(() => iterable.groupByToTransform(
+          other, keySelector, (it) => it.toUpperCase()));
+      expect(e.message, allOf(contains("null"), contains("keySelector")));
+    });
+    test("groupByToTransform requires valueTransform to be non null", () {
+      final iterable = iterableOf(["a", "b", "c"]);
+      final String Function(String) valueSelector = null;
+      final other = mutableMapOf<String, KMutableList<String>>();
+      final e = catchException<ArgumentError>(() => iterable.groupByToTransform(
+          other, (it) => it.toUpperCase(), valueSelector));
+      expect(e.message, allOf(contains("null"), contains("valueTransform")));
+    });
+  });
+
   group("indexOf", () {
     test("returns index", () {
       final iterable = iterableOf(["a", "b", "c", "b"]);

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -625,10 +625,11 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
       }
     });
     test("filterIndexedTo super type", () {
-      final KIterable<int> iterable = listOf([4, 25, -12, 10]);
+      final iterable = iterableOf([4, 25, -12, 10]);
       final result = mutableListOf<num>();
       final filtered = iterable.filterIndexedTo(result, (i, it) => it < 10);
       expect(identical(result, filtered), isTrue);
+      if (ordered) {
         expect(result, listOf([4, -12]));
       } else {
         expect(result.toSet(), equals(setOf([4, -12])));
@@ -1944,7 +1945,6 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
     });
   });
 
-
   group("toCollection", () {
     test("toCollection same type", () {
       final iterable = iterableOf([4, 25, -12, 10]);
@@ -1952,9 +1952,9 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
       final filtered = iterable.toCollection(result);
       expect(identical(result, filtered), isTrue);
       if (ordered) {
-        expect(result, listOf([4, -12]));
+        expect(result, listOf([4, 25, -12, 10]));
       } else {
-        expect(result.toSet(), setOf([4, -12]));
+        expect(result.toSet(), setOf([4, 25, -12, 10]));
       }
     });
     test("toCollection super type", () {
@@ -1963,16 +1963,16 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
       final filtered = iterable.toCollection(result);
       expect(identical(result, filtered), isTrue);
       if (ordered) {
-        expect(result, listOf([4, -12]));
+        expect(result, listOf([4, 25, -12, 10]));
       } else {
-        expect(result.toSet(), equals(setOf([4, -12])));
+        expect(result.toSet(), equals(setOf([4, 25, -12, 10])));
       }
     });
     test("toCollection wrong type throws", () {
       final iterable = iterableOf([4, 25, -12, 10]);
       final result = mutableListOf<String>();
-      final e = catchException<ArgumentError>(
-              () => iterable.toCollection(result));
+      final e =
+          catchException<ArgumentError>(() => iterable.toCollection(result));
       expect(
           e.message,
           allOf(
@@ -1984,13 +1984,12 @@ void testIterable(KIterable<T> Function<T>() emptyIterable,
     });
     test("toCollection requires destination to be non null", () {
       final iterable = iterableOf(["a", "b", "c"]);
-      final e = catchException<ArgumentError>(
-              () => iterable.toCollection(null, (it) => true));
+      final e =
+          catchException<ArgumentError>(() => iterable.toCollection(null));
       expect(e.message, allOf(contains("null"), contains("destination")));
     });
   });
-  
-  
+
   group("windowed", () {
     test("default step", () {
       expect(


### PR DESCRIPTION
Makes `toCollection` compile by making destination type dynamic and runtime checked. This even allows contravariants!